### PR TITLE
add LINODE_NB_PREFIX environment variable to prefix NodeBalancer labels 

### DIFF
--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -49,9 +49,9 @@ func newCloud() (cloudprovider.Interface, error) {
 	}
 
 	nbPrefix := os.Getenv(nbPrefixEnv)
-	matched, _ := regexp.MatchString(`^[0-9A-Za-z_-]{,9}$`, nbPrefixEnv)
+	matched, _ := regexp.MatchString(`^[0-9A-Za-z_-]{,12}$`, nbPrefixEnv)
 	if !matched {
-		return nil, fmt.Errorf("%s must be up to 9 alphanumeric characters, including hyphen and underscore", nbPrefixEnv)
+		return nil, fmt.Errorf("%s must be up to 12 alphanumeric characters, including hyphen and underscore", nbPrefixEnv)
 	}
 
 	// Initialize Linode API Client

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -274,7 +274,7 @@ func (l *loadbalancers) lbByName(ctx context.Context, client *linodego.Client, n
 	return nil, lbNotFound
 }
 
-// l.GetLoadBalancerName is a Linode friendly version of cloudprovider.GetLoadBalancerName
+// GetLoadBalancerName is a Linode friendly version of cloudprovider.GetLoadBalancerName
 func (l *loadbalancers) GetLoadBalancerName(service *v1.Service) string {
 	// Linode NodeBalancer names must be 3-32 chars (letters, numbers, dashes, underscore)
 	ret := string(service.UID)

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -261,6 +261,24 @@ b8QPmGZdja1VyGqpAMkPmQOu9N5RbhKw1UOU/XGa31p6v96oayL+u8Q=
 	}
 }
 
+func TestGetLoadBalancer_prefix(t *testing.T) {
+	lb := &loadbalancers{nil, "region", "prefix-"}
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:         randString(10),
+			UID:          "abc123",
+			GenerateName: "foo",
+			ClusterName:  "bar",
+		},
+	}
+
+	label := lb.GetLoadBalancerName(svc)
+
+	if label != "prefix-abc123" {
+		t.Error("unexpected loadbalancer name")
+	}
+}
+
 func Test_getTLSPorts(t *testing.T) {
 	testcases := []struct {
 		name     string

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -67,7 +67,7 @@ func testCreateNodeBalancer(t *testing.T, client *linodego.Client) {
 			},
 		},
 	}
-	lb := &loadbalancers{client, "us-west"}
+	lb := &loadbalancers{client, "us-west", "test-pre-"}
 	id, err := lb.createNodeBalancer(context.TODO(), svc)
 	if id == -1 {
 		t.Error("unexpected nodeID")
@@ -522,7 +522,7 @@ func testBuildLoadBalancerRequest(t *testing.T, client *linodego.Client) {
 		},
 	}
 
-	lb := &loadbalancers{client, "us-west"}
+	lb := &loadbalancers{client, "us-west", "test-pre-"}
 	id, err := lb.buildLoadBalancerRequest(context.TODO(), svc, nodes)
 	if id == "" {
 		t.Error("unexpected nodeID")
@@ -557,6 +557,9 @@ func testEnsureLoadBalancerDeleted(t *testing.T, client *linodego.Client) {
 			},
 		},
 	}
+
+	const testClusterName = "linodelb"
+
 	testcases := []struct {
 		name        string
 		clusterName string
@@ -565,13 +568,13 @@ func testEnsureLoadBalancerDeleted(t *testing.T, client *linodego.Client) {
 	}{
 		{
 			"load balancer delete",
-			"linodelb",
+			testClusterName,
 			svc,
 			nil,
 		},
 		{
 			"load balancer not exists",
-			"linodelb",
+			testClusterName,
 			&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "notexists",
@@ -595,12 +598,12 @@ func testEnsureLoadBalancerDeleted(t *testing.T, client *linodego.Client) {
 		},
 	}
 
-	lb := &loadbalancers{client, "us-west"}
+	lb := &loadbalancers{client, "us-west", "test-pre-"}
 	_, err := lb.createNodeBalancer(context.TODO(), svc)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = lb.EnsureLoadBalancerDeleted(context.TODO(), "lnodelb", svc) }()
+	defer func(testClusterName string) { _ = lb.EnsureLoadBalancerDeleted(context.TODO(), testClusterName, svc) }(testClusterName)
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
@@ -641,7 +644,7 @@ func testEnsureLoadBalancer(t *testing.T, client *linodego.Client) {
 		},
 	}
 
-	lb := &loadbalancers{client, "us-west"}
+	lb := &loadbalancers{client, "us-west", "test-pre-"}
 
 	_, err := lb.createNodeBalancer(context.TODO(), svc)
 	if err != nil {
@@ -735,7 +738,7 @@ func testEnsureLoadBalancer(t *testing.T, client *linodego.Client) {
 }
 
 func testGetLoadBalancer(t *testing.T, client *linodego.Client) {
-	lb := &loadbalancers{client, "us-west"}
+	lb := &loadbalancers{client, "us-west", "test-pre-"}
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -261,7 +261,7 @@ b8QPmGZdja1VyGqpAMkPmQOu9N5RbhKw1UOU/XGa31p6v96oayL+u8Q=
 	}
 }
 
-func TestGetLoadBalancer_prefix(t *testing.T) {
+func TestGetLoadBalancerName_prefix(t *testing.T) {
 	lb := &loadbalancers{nil, "region", "prefix-"}
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -274,8 +274,12 @@ func TestGetLoadBalancer_prefix(t *testing.T) {
 
 	label := lb.GetLoadBalancerName(svc)
 
-	if label != "prefix-abc123" {
+	expected := "prefix-abc123"
+
+	if label != expected {
 		t.Error("unexpected loadbalancer name")
+		t.Logf("expected: %q", expected)
+		t.Logf("actual: %q", label)
 	}
 }
 

--- a/hack/deploy/ccm-linode-template.yaml
+++ b/hack/deploy/ccm-linode-template.yaml
@@ -88,6 +88,8 @@ spec:
                 secretKeyRef:
                   name: ccm-linode
                   key: region
+            - name: LINODE_NB_PREFIX
+              value: {{ .Values.linodeNBPrefix }}
       volumes:
       - name: k8s
         hostPath:

--- a/hack/deploy/generate-manifest.sh
+++ b/hack/deploy/generate-manifest.sh
@@ -1,21 +1,28 @@
 #!/bin/bash
 
-set -o pipefail -o noclobber -o nounset
+set -o pipefail -o noclobber
 
 die() { echo "$*" 1>&2; exit 1; }
 
-[ "$#" -eq 2 ] || die "First argument must be a Linode APIv4 Personal Access Token with all permissions.
+[ "$#" -lt "2" -o "$#" -gt "3" ] && die "First argument must be a Linode APIv4 Personal Access Token with all permissions.
 (https://cloud.linode.com/profile/tokens)
 
 Second argument must be a Linode region.
 (https://api.linode.com/v4/regions)
 
+Third Argument (Optional) is a Linode NodeBalancer Prefix:
+(Up to 9 alpha-numeric characters [A-Za-z0-9_-])
+
 Example:
-$ ./generate-manifest.sh \$LINODE_API_TOKEN us-east"
+$ ./generate-manifest.sh \$LINODE_API_TOKEN us-east k8s-"
 
 ENCODED_TOKEN=$(echo -n $1 | base64)
 ENCODED_REGION=$(echo -n $2 | base64)
+LINODE_NB_PREFIX="$3"
 
-cat ccm-linode-template.yaml |
-sed -e "s|{{ .Values.apiTokenB64 }}|$ENCODED_TOKEN|" |
-sed -e "s|{{ .Values.linodeRegionB64 }}|$ENCODED_REGION|" > ccm-linode.yaml
+
+sed \
+ -e "s|{{ .Values.apiTokenB64 }}|$ENCODED_TOKEN|" \
+ -e "s|{{ .Values.linodeRegionB64 }}|$ENCODED_REGION|" \
+ -e "s|{{ .Values.linodeNBPrefix }}|$LINODE_NB_PREFIX|" \
+ ccm-linode-template.yaml > ccm-linode.yaml

--- a/hack/deploy/generate-manifest.sh
+++ b/hack/deploy/generate-manifest.sh
@@ -11,7 +11,7 @@ Second argument must be a Linode region.
 (https://api.linode.com/v4/regions)
 
 Third Argument (Optional) is a Linode NodeBalancer Prefix:
-(Up to 9 alpha-numeric characters [A-Za-z0-9_-])
+(Up to 12 alpha-numeric characters [A-Za-z0-9_-])
 
 Example:
 $ ./generate-manifest.sh \$LINODE_API_TOKEN us-east k8s-"


### PR DESCRIPTION
Adds a `LINODE_NB_PREFIX` variable which, if present, will prefix all created Linode NodeBalancers with that prefix before the autogenerated unique ID.

For example, to create NodeBalancers named "k8s-12abe93d...." (32 characters will be used)

```yaml
          - name: LINODE_NB_PREFIX
            value: k8s-
```

The prefix is restricted to 12 characters to maintain some value from the UUID.

---

**For Compatibility** with earlier versions, set the `LINODE_NB_PREFIX` to `a`.