### PR TITLE
Added KubeconfigFlag option based on CCM --kubeconfig flag

### DIFF
--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/linode/linodego"
+	"github.com/spf13/pflag"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
 )
@@ -21,7 +22,8 @@ const (
 // We expect it to be initialized with flags external to this package, likely in
 // main.go
 var Options struct {
-	LinodeGoDebug bool
+	KubeconfigFlag *pflag.Flag
+	LinodeGoDebug  bool
 }
 
 type linodeCloud struct {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,13 @@ func main() {
 	// Add Linode-specific flags
 	command.Flags().BoolVar(&linode.Options.LinodeGoDebug, "linodego-debug", false, "enables debug output for the LinodeAPI wrapper")
 
+	// Make the Linode-specific CCM bits aware of the kubeconfig flag
+	linode.Options.KubeconfigFlag = command.Flags().Lookup("kubeconfig")
+	if linode.Options.KubeconfigFlag == nil {
+		fmt.Fprintf(os.Stderr, "kubeconfig missing from CCM flag set\n")
+		os.Exit(1)
+	}
+
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 


### PR DESCRIPTION
When explicitly passing a kubeconfig via --kubeconfig, the CCM would use the provided kubeconfig but Linode-specific logic would not. This would lead to errors when attempting to use a Kubernetes client to get TLS secrets, as the CCM was attempting to get those from the cluster it was in as opposed to the cluster it was pointing to based on the given kubeconfig.

This addresses that issue by defining and setting a KubeconfigFlag option in linode.Options, then using that when creating a Kubernetes client. The presence of the flag in the flag set is required, but its use is not; if --kubeconfig is not set, the CCM will default to authenticating using the in-cluster config.

I'm pretty sure this works, but still need to test it 👼 Placing it here now for review.
