### PR TITLE
Add error checking when listing NodeBalancers

### DIFF
--- a/e2e/test/framework/loadbalancer_suit.go
+++ b/e2e/test/framework/loadbalancer_suit.go
@@ -19,7 +19,11 @@ func (i *lbInvocation) getNodeBalancerID(svcName string) (int, error) {
 		return -1, err
 	}
 
-	nbList, err := i.linodeClient.ListNodeBalancers(context.Background(), nil)
+	nbList, errListNodeBalancers := i.linodeClient.ListNodeBalancers(context.Background(), nil)
+
+	if errListNodeBalancers != nil {
+		return -1, errListNodeBalancers
+	}
 
 	for _, nb := range nbList {
 		if *nb.IPv4 == ip {


### PR DESCRIPTION
Adding error checking when listing NBs seems to have been missed earlier. This takes care of that.