### PR TITLE
Rebuild all NodeBalancer configs on update

### DIFF
--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -455,20 +455,6 @@ func (f *fakeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
 
-			for _, n := range nbcco.Nodes {
-				node := linodego.NodeBalancerNode{
-					ID:             rand.Intn(99999),
-					Address:        n.Address,
-					Label:          n.Label,
-					Weight:         n.Weight,
-					Mode:           n.Mode,
-					ConfigID:       nbcc.ID,
-					NodeBalancerID: nbid,
-				}
-
-				f.nbn[strconv.Itoa(node.ID)] = &node
-			}
-
 			resp, err := json.Marshal(nbcc)
 			if err != nil {
 				f.t.Fatal(err)

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -191,12 +191,10 @@ func (l *loadbalancers) UpdateLoadBalancer(ctx context.Context, clusterName stri
 		if currentNBCfg == nil {
 			createOpts := newNBCfg.GetCreateOptions()
 
-			newNBCfg, err := l.client.CreateNodeBalancerConfig(ctx, lb.ID, createOpts)
+			currentNBCfg, err = l.client.CreateNodeBalancerConfig(ctx, lb.ID, createOpts)
 			if err != nil {
 				return fmt.Errorf("[port %d] error creating NodeBalancer config: %v", int(port.Port), err)
 			}
-
-			currentNBCfg = newNBCfg
 		}
 
 		rebuildOpts := currentNBCfg.GetRebuildOptions()

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -178,31 +178,32 @@ func (l *loadbalancers) UpdateLoadBalancer(ctx context.Context, clusterName stri
 		}
 
 		// Look for an existing config for this port
-		var existingNBCfg *linodego.NodeBalancerConfig
-		for _, nbc := range nbCfgs {
-			nbc := nbc
+		var currentNBCfg *linodego.NodeBalancerConfig
+		for i := range nbCfgs {
+			nbc := nbCfgs[i]
 			if nbc.Port == int(port.Port) {
-				existingNBCfg = &nbc
+				currentNBCfg = &nbc
 				break
 			}
 		}
 
-		// If there's an existing config, rebuild it, otherwise, create it
-		if existingNBCfg != nil {
-			rebuildOpts := newNBCfg.GetRebuildOptions()
-			rebuildOpts.Nodes = newNBNodes
-
-			if _, err = l.client.RebuildNodeBalancerConfig(ctx, lb.ID, existingNBCfg.ID, rebuildOpts); err != nil {
-				return fmt.Errorf("[port %d] error rebuilding NodeBalancer config: %v", int(port.Port), err)
-			}
-		} else {
+		// If there's no existing config, create it
+		if currentNBCfg == nil {
 			createOpts := newNBCfg.GetCreateOptions()
-			createOpts.Nodes = newNBNodes
 
-			_, err := l.client.CreateNodeBalancerConfig(ctx, lb.ID, createOpts)
+			newNBCfg, err := l.client.CreateNodeBalancerConfig(ctx, lb.ID, createOpts)
 			if err != nil {
-				return err
+				return fmt.Errorf("[port %d] error creating NodeBalancer config: %v", int(port.Port), err)
 			}
+
+			currentNBCfg = newNBCfg
+		}
+
+		rebuildOpts := currentNBCfg.GetRebuildOptions()
+		rebuildOpts.Nodes = newNBNodes
+
+		if _, err = l.client.RebuildNodeBalancerConfig(ctx, lb.ID, currentNBCfg.ID, rebuildOpts); err != nil {
+			return fmt.Errorf("[port %d] error rebuilding NodeBalancer config: %v", int(port.Port), err)
 		}
 	}
 


### PR DESCRIPTION
It turns out that according to [the API spec](https://developers.linode.com/api/v4/nodebalancers-node-balancer-id-configs/#post), and contrary to [linodego](https://github.com/linode/linodego/blob/master/nodebalancer_configs.go#L104), NodeBalancer configs do not get populated with nodes at create time; they only get populated with nodes at rebuild time. As a result, LoadBalancer services that were created, then updated with new ports weren't getting nodes associated with those ports.

This pull request resolves that issue by creating configs for ports that don't exist, then rebuilding all configs for all ports.