### PR TITLE
Ensure rebuild options are captured correctly if NodeBalancer config exists

### DIFF
--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -220,6 +220,7 @@ func (l *loadbalancers) UpdateLoadBalancer(ctx context.Context, clusterName stri
 		}
 
 		// If there's no existing config, create it
+		var rebuildOpts linodego.NodeBalancerConfigRebuildOptions
 		if currentNBCfg == nil {
 			createOpts := newNBCfg.GetCreateOptions()
 
@@ -228,9 +229,11 @@ func (l *loadbalancers) UpdateLoadBalancer(ctx context.Context, clusterName stri
 				sentry.CaptureError(ctx, err)
 				return fmt.Errorf("[port %d] error creating NodeBalancer config: %v", int(port.Port), err)
 			}
+			rebuildOpts = currentNBCfg.GetRebuildOptions()
+		} else {
+			rebuildOpts = newNBCfg.GetRebuildOptions()
 		}
 
-		rebuildOpts := currentNBCfg.GetRebuildOptions()
 		rebuildOpts.Nodes = newNBNodes
 
 		if _, err = l.client.RebuildNodeBalancerConfig(ctx, lb.ID, currentNBCfg.ID, rebuildOpts); err != nil {


### PR DESCRIPTION

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

Bugfix: Updating NodeBalancer port configs is broken. If you attempt to update a port configuration, the NodeBalancer does not update.

This PR addresses this and ensures NodeBalancer port configs are updated correctly.