### PR TITLE
Add loadbalancer preserve annotation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,6 +40,7 @@ linters:
     - gochecknoglobals
     - wsl
     - gomnd
+    - godot
+    - goerr113
+    - nestif
   fast: false
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - GO111MODULE=off go get github.com/lawrencewoodman/roveralls
 
 install:
-  - wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin latest
+  - wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.27.0
 
 script:
   - make

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Annotation (Suffix) | Values | Default | Description
 `check-interval` | int | | Duration, in seconds, to wait between health checks
 `check-timeout` | int (1-30) | | Duration, in seconds, to wait for a health check to succeed before considering it a failure
 `check-attempts` | int (1-30) | | Number of health check failures necessary to remove a back-end from the service
-`check-passive` | bool | `false` | When `true`, `5xx` status codes will cause the health check to fail
+`check-passive` | [bool](#annotation-bool-values) | `false` | When `true`, `5xx` status codes will cause the health check to fail
+`preserve` | [bool](#annotation-bool-values) | `false` | When `true`, deleting a `LoadBalancer` service does not delete the underlying NodeBalancer
 
 #### Deprecated Annotations
 
@@ -62,7 +63,11 @@ Annotation (Suffix) | Values | Default | Description
 `protocol` | `tcp`, `http`, `https` | `tcp` | This annotation is used to specify the default protocol for Linode NodeBalancer. For ports specified in the `linode-loadbalancer-tls-ports` annotation, this protocol is overwritten to `https`
 `tls` | json array (e.g. `[ { "tls-secret-name": "prod-app-tls", "port": 443}, {"tls-secret-name": "dev-app-tls", "port": 8443} ]`) | | Specifies TLS ports with their corresponding secrets, the secret type should be `kubernetes.io/tls
 
-For example,
+#### Annotation bool values
+
+For annotations with bool value types, `"1"`, `"t"`,  `"T"`, `"True"`, `"true"` and `"True"` are valid string representations of `true`. Any other values will be interpreted as false. For more details, see [strconv.ParseBool](https://golang.org/pkg/strconv/#ParseBool).
+
+#### Example usage
 
 ```yaml
 apiVersion: v1

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -1,8 +1,10 @@
 package linode
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -23,6 +25,14 @@ type fakeAPI struct {
 	nb       map[string]*linodego.NodeBalancer
 	nbc      map[string]*linodego.NodeBalancerConfig
 	nbn      map[string]*linodego.NodeBalancerNode
+
+	requests map[fakeRequest]struct{}
+}
+
+type fakeRequest struct {
+	Path string
+	Body string
+	Method string
 }
 
 type filterStruct struct {
@@ -72,10 +82,33 @@ func newFake(t *testing.T) *fakeAPI {
 		nb:  make(map[string]*linodego.NodeBalancer),
 		nbc: make(map[string]*linodego.NodeBalancerConfig),
 		nbn: make(map[string]*linodego.NodeBalancerNode),
+		requests: make(map[fakeRequest]struct{}),
 	}
 }
 
+func (f *fakeAPI) recordRequest(r *http.Request) {
+	bodyBytes, _ := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+	f.requests[fakeRequest{
+		Path:    r.URL.Path,
+		Method: r.Method,
+		Body:   string(bodyBytes),
+	}] = struct{}{}
+}
+
+func (f *fakeAPI) didRequestOccur(method, path, body string) bool {
+	_, ok := f.requests[fakeRequest{
+		Path: path,
+		Method: method,
+		Body: body,
+	}]
+	return ok
+}
+
 func (f *fakeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.recordRequest(r)
+
 	w.Header().Set("Content-Type", "application/json")
 	urlPath := r.URL.Path
 	switch r.Method {

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -30,8 +30,8 @@ type fakeAPI struct {
 }
 
 type fakeRequest struct {
-	Path string
-	Body string
+	Path   string
+	Body   string
 	Method string
 }
 
@@ -79,9 +79,9 @@ func newFake(t *testing.T) *fakeAPI {
 				Region:   region,
 			},
 		},
-		nb:  make(map[string]*linodego.NodeBalancer),
-		nbc: make(map[string]*linodego.NodeBalancerConfig),
-		nbn: make(map[string]*linodego.NodeBalancerNode),
+		nb:       make(map[string]*linodego.NodeBalancer),
+		nbc:      make(map[string]*linodego.NodeBalancerConfig),
+		nbn:      make(map[string]*linodego.NodeBalancerNode),
 		requests: make(map[fakeRequest]struct{}),
 	}
 }
@@ -91,7 +91,7 @@ func (f *fakeAPI) recordRequest(r *http.Request) {
 	r.Body.Close()
 	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
 	f.requests[fakeRequest{
-		Path:    r.URL.Path,
+		Path:   r.URL.Path,
 		Method: r.Method,
 		Body:   string(bodyBytes),
 	}] = struct{}{}
@@ -99,9 +99,9 @@ func (f *fakeAPI) recordRequest(r *http.Request) {
 
 func (f *fakeAPI) didRequestOccur(method, path, body string) bool {
 	_, ok := f.requests[fakeRequest{
-		Path: path,
+		Path:   path,
 		Method: method,
-		Body: body,
+		Body:   body,
 	}]
 	return ok
 }

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -278,9 +278,7 @@ func (l *loadbalancers) EnsureLoadBalancerDeleted(ctx context.Context, clusterNa
 
 	// Don't delete the underlying nodebalancer if the service has the preserve annotation.
 	if preserveRaw, ok := service.Annotations[annLinodeLoadBalancerPreserve]; ok {
-		if preserve, err := strconv.ParseBool(preserveRaw); err != nil {
-			return fmt.Errorf("failed to parse annotation %s value: %s", annLinodeLoadBalancerPreserve, err)
-		} else if preserve {
+		if preserve, err := strconv.ParseBool(preserveRaw); err == nil && preserve {
 			return nil
 		}
 	}

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -798,7 +798,6 @@ func testEnsureLoadBalancerPreserveAnnotation(t *testing.T, client *linodego.Cli
 	lb := &loadbalancers{client, "us-west", nil}
 	for _, test := range []struct {
 		name        string
-		err         error
 		deleted     bool
 		annotations map[string]string
 	}{
@@ -813,10 +812,9 @@ func testEnsureLoadBalancerPreserveAnnotation(t *testing.T, client *linodego.Cli
 			deleted:     true,
 		},
 		{
-			name:        "invalid value",
+			name:        "invalid value treated as false (deleted)",
 			annotations: map[string]string{annLinodeLoadBalancerPreserve: "bogus"},
-			err:         fmt.Errorf("failed to parse annotation %s value: strconv.ParseBool: parsing \"bogus\": invalid syntax", annLinodeLoadBalancerPreserve),
-			deleted:     false,
+			deleted:     true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -843,10 +841,8 @@ func testEnsureLoadBalancerPreserveAnnotation(t *testing.T, client *linodego.Cli
 				t.Fatal("load balancer was unexpectedly preserved")
 			}
 
-			if !reflect.DeepEqual(err, test.err) {
-				t.Error("unexpected error")
-				t.Logf("expected: %v", test.err)
-				t.Logf("actual: %v", err)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
 			}
 		})
 	}

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -51,11 +51,11 @@ github.com/juju/loggo v0.0.0-20180524022052-584905176618/go.mod h1:vgyd7OREkbtVE
 github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/linode/linodego v0.7.1 h1:4WZmMpSA2NRwlPZcc0+4Gyn7rr99Evk9bnr0B3gXRKE=
-github.com/linode/linodego v0.7.1/go.mod h1:ga11n3ivecUrPCHN0rANxKmfWBJVkOXfLMZinAbj2sY=
 github.com/linode/linodego v0.11.0 h1:3RjqvGd/d93l2zmC6zMytaEXWXTPjP5IjNbYmtN3p9w=
 github.com/linode/linodego v0.11.0/go.mod h1:cQFzVqVu5KeFy2ZSTWTA/qVNYYa9ZY8uePJZsFG7EYs=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -112,6 +112,7 @@ google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO50
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/e2e/test/ccm_suite_test.go
+++ b/e2e/test/ccm_suite_test.go
@@ -53,7 +53,7 @@ func TestE2e(t *testing.T) {
 
 }
 
-var getLinodeClient = func() linodego.Client {
+var getLinodeClient = func() *linodego.Client {
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: framework.ApiToken})
 
 	oauth2Client := &http.Client{
@@ -64,7 +64,7 @@ var getLinodeClient = func() linodego.Client {
 
 	linodeClient := linodego.NewClient(oauth2Client)
 
-	return linodeClient
+	return &linodeClient
 }
 
 var _ = BeforeSuite(func() {
@@ -85,7 +85,7 @@ var _ = BeforeSuite(func() {
 	linodeClient := getLinodeClient()
 
 	// Framework
-	root = framework.New(config, kubeClient, linodeClient)
+	root = framework.New(config, kubeClient, *linodeClient)
 
 	By("Using Namespace " + root.Namespace())
 	err = root.CreateNamespace()

--- a/e2e/test/framework/loadbalancer_suit.go
+++ b/e2e/test/framework/loadbalancer_suit.go
@@ -13,7 +13,7 @@ func (i *lbInvocation) GetHTTPEndpoints() ([]string, error) {
 	return i.getLoadBalancerURLs()
 }
 
-func (i *lbInvocation) getNodeBalancerID(svcName string) (int, error) {
+func (i *lbInvocation) GetNodeBalancerID(svcName string) (int, error) {
 	ip, err := i.waitForLoadBalancerIP(svcName)
 	if err != nil {
 		return -1, err
@@ -34,7 +34,7 @@ func (i *lbInvocation) getNodeBalancerID(svcName string) (int, error) {
 }
 
 func (i *lbInvocation) GetNodeBalancerConfig(svcName string) (*linodego.NodeBalancerConfig, error) {
-	id, err := i.getNodeBalancerID(svcName)
+	id, err := i.GetNodeBalancerID(svcName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change adds an annotation that can be used on services of `type: LoadBalancer` to ensure that the underlying NodeBalancer is not deleted when the service is.

This is the first of two PRs to enable reusing LoadBalancers.