### PR TITLE
Hardcode --authentication-skip-lookup=true to short-circuit ConfigMap auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ run: build
 	dist/linode-cloud-controller-manager \
 		--logtostderr=true \
 		--stderrthreshold=INFO \
-		--cloud-provider=linode \
 		--kubeconfig=${KUBECONFIG}
 
 .PHONY: run-debug
@@ -77,7 +76,6 @@ run-debug: build
 	dist/linode-cloud-controller-manager \
 		--logtostderr=true \
 		--stderrthreshold=INFO \
-		--cloud-provider=linode \
 		--kubeconfig=${KUBECONFIG} \
 		--linodego-debug
 

--- a/deploy/ccm-linode-template.yaml
+++ b/deploy/ccm-linode-template.yaml
@@ -101,7 +101,6 @@ spec:
           imagePullPolicy: Always
           name: ccm-linode
           args:
-          - --cloud-provider=linode
           - --leader-elect-resource-lock=endpoints
           - --v=3
           - --port=0

--- a/deploy/ccm-linode-template.yaml
+++ b/deploy/ccm-linode-template.yaml
@@ -15,15 +15,44 @@ metadata:
   name: ccm-linode
   namespace: kube-system
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ccm-linode-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get", "watch", "list", "update", "create"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "watch", "list", "update", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["nodes/status"]
+  verbs: ["get", "watch", "list", "update", "delete", "patch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "watch", "list", "update", "create", "patch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "watch", "list", "update"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["services/status"]
+  verbs: ["get", "watch", "list", "update", "patch"]
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:ccm-linode
+  name: ccm-linode-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  # TODO: make these permissions more fine-grained
-  name: cluster-admin
+  name: ccm-linode-clusterrole
 subjects:
 - kind: ServiceAccount
   name: ccm-linode


### PR DESCRIPTION
Resolves #91

This change hardcodes some flags. Setting `--authentication-skip-lookup=true` short circuits configmap lookup for authentication (no longer needed), allowing for more fine-grained permissions. Also hardcodes --cloud-provider to "linode".

The manifest template has also been updated to use a restricted clusterrolebinding.