### PR TITLE
feat: truncate long labels in nodebalancers

### DIFF
--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -644,12 +644,20 @@ func (l *loadbalancers) buildLoadBalancerRequest(ctx context.Context, clusterNam
 	return l.createNodeBalancer(ctx, clusterName, service, configs)
 }
 
+func trimString(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[:maxLen]
+	}
+	return s
+}
+
 func (l *loadbalancers) buildNodeBalancerNodeCreateOptions(node *v1.Node, nodePort int32) linodego.NodeBalancerNodeCreateOptions {
 	return linodego.NodeBalancerNodeCreateOptions{
 		Address: fmt.Sprintf("%v:%v", getNodePrivateIP(node), nodePort),
-		Label:   node.Name,
-		Mode:    "accept",
-		Weight:  100,
+		// NodeBalancer backends must be 3-32 chars in length
+		Label:  trimString(node.Name, 32),
+		Mode:   "accept",
+		Weight: 100,
 	}
 }
 

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -2114,3 +2114,45 @@ func addTLSSecret(t *testing.T, kubeClient kubernetes.Interface) {
 		t.Fatalf("failed to add TLS secret: %s\n", err)
 	}
 }
+
+func Test_LoadbalNodeNameCoercion(t *testing.T) {
+	type testCase struct {
+		nodeName       string
+		padding        string
+		expectedOutput string
+	}
+	testCases := []testCase{
+		{
+			nodeName:       "n",
+			padding:        "z",
+			expectedOutput: "zzn",
+		},
+		{
+			nodeName:       "n",
+			padding:        "node-",
+			expectedOutput: "node-n",
+		},
+		{
+			nodeName:       "n",
+			padding:        "",
+			expectedOutput: "xxn",
+		},
+		{
+			nodeName:       "infra-logging-controlplane-3-atl1-us-prod",
+			padding:        "node-",
+			expectedOutput: "infra-logging-controlplane-3-atl",
+		},
+		{
+			nodeName:       "node1",
+			padding:        "node-",
+			expectedOutput: "node1",
+		},
+	}
+
+	for _, tc := range testCases {
+		if out := coerceString(tc.nodeName, 3, 32, tc.padding); out != tc.expectedOutput {
+			t.Fatalf("Expected loadbal backend name to be %s (got: %s)", tc.expectedOutput, out)
+		}
+	}
+
+}


### PR DESCRIPTION
Nodebalancer backends can have a max label length of 32 chars.

If a k8s node's name is longer than 32 chars, creating a nodebalancer fails.

Example error:
```console
E0307 22:31:47.275176       1 controller.go:307] error processing service traefik/traefik (will retry):
failed to ensure load balancer: [400] [configs[0].nodes[0].label] Length must be 3-32 characters;
[configs[0].nodes[1].label] Length must be 3-32 characters;
[configs[0].nodes[2].label] Length must be 3-32 characters;
```

### General:

* [X] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [X] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [X] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [X] Are you addressing a single feature in this PR? 
1. [X] Are your commits atomic, addressing one change per commit?
1. [X] Are you following the conventions of the language? 
1. [X] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [X] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

