### PR TITLE
Short circuit LB cleanup if no annotations present

### DIFF
--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -42,8 +42,8 @@ func newFake(t *testing.T) *fakeAPI {
 	}
 }
 
-func (f *fakeAPI) Reset() {
-	*f = *newFake(f.t)
+func (f *fakeAPI) ResetRequests() {
+	f.requests = make(map[fakeRequest]struct{})
 }
 
 func (f *fakeAPI) recordRequest(r *http.Request) {

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -42,6 +42,10 @@ func newFake(t *testing.T) *fakeAPI {
 	}
 }
 
+func (f *fakeAPI) Reset() {
+	*f = *newFake(f.t)
+}
+
 func (f *fakeAPI) recordRequest(r *http.Request) {
 	bodyBytes, _ := ioutil.ReadAll(r.Body)
 	r.Body.Close()

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -140,6 +140,16 @@ func (l *loadbalancers) getNodeBalancerByStatus(ctx context.Context, service *v1
 // LoadBalancer status; if they are different (because of an updated NodeBalancerID
 // annotation), the old one is deleted.
 func (l *loadbalancers) cleanupOldNodeBalancer(ctx context.Context, service *v1.Service) error {
+	// unless there's an annotation, we can never get a past and current NB to differ,
+	// because they're looked up the same way
+	// TODO(okokes): just copy pasted from elsewhere, encapsulate it somehow
+	rawID, _ := getServiceAnnotation(service, annLinodeNodeBalancerID)
+	id, idErr := strconv.Atoi(rawID)
+	hasIDAnn := idErr == nil && id != 0
+	if !hasIDAnn {
+		return nil
+	}
+
 	previousNB, err := l.getNodeBalancerByStatus(ctx, service)
 	switch err.(type) {
 	case nil:

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -142,11 +142,7 @@ func (l *loadbalancers) getNodeBalancerByStatus(ctx context.Context, service *v1
 func (l *loadbalancers) cleanupOldNodeBalancer(ctx context.Context, service *v1.Service) error {
 	// unless there's an annotation, we can never get a past and current NB to differ,
 	// because they're looked up the same way
-	// TODO(okokes): just copy pasted from elsewhere, encapsulate it somehow
-	rawID, _ := getServiceAnnotation(service, annLinodeNodeBalancerID)
-	id, idErr := strconv.Atoi(rawID)
-	hasIDAnn := idErr == nil && id != 0
-	if !hasIDAnn {
+	if _, ok := getServiceAnnotation(service, annLinodeNodeBalancerID); !ok {
 		return nil
 	}
 

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -166,6 +166,10 @@ func TestCCMLoadBalancers(t *testing.T) {
 			name: "makeLoadBalancerStatus",
 			f:    testMakeLoadBalancerStatus,
 		},
+		{
+			name: "Cleanup does not all the API unless Service annotated",
+			f:    testCleanupDoesntCall,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1442,6 +1446,50 @@ func testMakeLoadBalancerStatus(t *testing.T, client *linodego.Client, _ *fakeAP
 	if !reflect.DeepEqual(status, expectedStatus) {
 		t.Errorf("expected status for %q annotated service to be %#v; got %#v", annLinodeHostnameOnlyIngress, expectedStatus, status)
 	}
+}
+
+func testCleanupDoesntCall(t *testing.T, client *linodego.Client, fakeAPI *fakeAPI) {
+	ipv4 := "192.168.0.1"
+	hostname := "nb-192-168-0-1.newark.nodebalancer.linode.com"
+	nb := &linodego.NodeBalancer{
+		IPv4:     &ipv4,
+		Hostname: &hostname,
+	}
+
+	svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
+	svcAnn := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test",
+			Annotations: map[string]string{annLinodeNodeBalancerID: "12345"},
+		},
+	}
+	svc.Status.LoadBalancer = *makeLoadBalancerStatus(svc, nb)
+	svcAnn.Status.LoadBalancer = *makeLoadBalancerStatus(svc, nb)
+	lb := &loadbalancers{client, "us-west", nil}
+
+	t.Run("non-annotated service shouldn't call the API during cleanup", func(t *testing.T) {
+		if err := lb.cleanupOldNodeBalancer(context.TODO(), svc); err != nil {
+			t.Fatal(err)
+		}
+		if len(fakeAPI.requests) != 0 {
+			t.Fatalf("unexpected API calls: %v", fakeAPI.requests)
+		}
+	})
+
+	// TODO(okokes): note that we're polluting fakeAPI between these subtests (not an issue per-se here, but not ideal)
+	t.Run("annotated service calls the API to load said NB", func(t *testing.T) {
+		if err := lb.cleanupOldNodeBalancer(context.TODO(), svcAnn); err != nil {
+			t.Fatal(err)
+		}
+		if len(fakeAPI.requests) != 1 {
+			t.Fatalf("unexpected API calls: %v", fakeAPI.requests)
+		}
+		// TODO(okokes): we need to change this to `/v4/nodebalancer` once we upgrade to linodego v1
+		if !fakeAPI.didRequestOccur("GET", "/nodebalancers", "") {
+			t.Fatalf("unexpected API calls: %v", fakeAPI.requests)
+		}
+		// TODO(okokes): check for DELETE on the old NB
+	})
 }
 
 func testGetNodeBalancerForServiceIDDoesNotExist(t *testing.T, client *linodego.Client, _ *fakeAPI) {

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -167,7 +167,7 @@ func TestCCMLoadBalancers(t *testing.T) {
 			f:    testMakeLoadBalancerStatus,
 		},
 		{
-			name: "Cleanup does not all the API unless Service annotated",
+			name: "Cleanup does not call the API unless Service annotated",
 			f:    testCleanupDoesntCall,
 		},
 	}
@@ -1467,6 +1467,7 @@ func testCleanupDoesntCall(t *testing.T, client *linodego.Client, fakeAPI *fakeA
 	svcAnn.Status.LoadBalancer = *makeLoadBalancerStatus(svc, nb)
 	lb := &loadbalancers{client, "us-west", nil}
 
+	fakeAPI.Reset()
 	t.Run("non-annotated service shouldn't call the API during cleanup", func(t *testing.T) {
 		if err := lb.cleanupOldNodeBalancer(context.TODO(), svc); err != nil {
 			t.Fatal(err)
@@ -1476,7 +1477,7 @@ func testCleanupDoesntCall(t *testing.T, client *linodego.Client, fakeAPI *fakeA
 		}
 	})
 
-	// TODO(okokes): note that we're polluting fakeAPI between these subtests (not an issue per-se here, but not ideal)
+	fakeAPI.Reset()
 	t.Run("annotated service calls the API to load said NB", func(t *testing.T) {
 		if err := lb.cleanupOldNodeBalancer(context.TODO(), svcAnn); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
### Rationale

If a service is not annotated, the two calls to new/old NBs will inevitably return the very same NB, so not NBs will get deleted in that method. We can thus short circuit this and not proceed to the API calls unless we have an annotation present within the service.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

