### PR TITLE
Adding an environment vairiable to change default hostname only ingress abilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 ### Configurations
 
-There are other variables that can be set to a different value. For list of all the modifiable variables/values, take a look at './deploy/chart/values.yaml'. 
+There are other variables that can be set to a different value. For list of all the modifiable variables/values, take a look at './deploy/chart/values.yaml'.
 
 Values can be set/overrided by using the '--set var=value,...' flag or by passing in a custom-values.yaml using '-f custom-values.yaml'.
 

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -47,6 +47,7 @@ spec:
                 secretKeyRef:
                   name: ccm-linode
                   key: region
+            {{- toYaml .Values.env | nindent 12 }}
       volumes:
         - name: k8s
           hostPath:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,4 +1,4 @@
-# apiToken [Required] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens) 
+# apiToken [Required] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens)
 apiToken: ""
 
 # region [Required] - Must be a Linode region. (https://api.linode.com/v4/regions)
@@ -20,7 +20,7 @@ image:
 namespace: "kube-system"
 
 # Set of default tolerations
-tolerations: 
+tolerations:
  # The CCM can run on Nodes tainted as masters
   - key: "node-role.kubernetes.io/master"
     effect: "NoSchedule"
@@ -37,3 +37,9 @@ tolerations:
   - key: node.kubernetes.io/unreachable
     operator: Exists
     effect: NoSchedule
+# This section adds the ability to pass environment variables to adjust CCM defaults
+# https://github.com/linode/linode-cloud-controller-manager/blob/master/cloud/linode/loadbalancers.go
+# LINODE_HOSTNAME_ONLY_INGRESS type bool is supported
+# env:
+  # - name: EXAMPLE_ENV_VAR
+  #   value: "true"


### PR DESCRIPTION
### General:
Adding the ability to set the Hostname Only Ingress vian ENVVARS because Gateway API does not yet support annotations.

See the conversation over at cilium: https://github.com/cilium/cilium/issues/25357


* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

