### PR TITLE
Allow passing linodeApitoken and region as secretRef

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,7 @@ jobs:
         run: make docker-build
       - name: unit test
         run: make test
+      - name: helm lint
+        run: make helm-lint
+      - name: helm template
+        run: make helm-template

--- a/deploy/chart/templates/ccm-linode.yaml
+++ b/deploy/chart/templates/ccm-linode.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secretRef }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ stringData:
   apiToken: {{ required ".Values.apiToken required" .Values.apiToken }}
   region: {{ required ".Values.region required" .Values.region }}
 type: Opaque
+{{- end }}

--- a/deploy/chart/templates/ccm-linode.yaml
+++ b/deploy/chart/templates/ccm-linode.yaml
@@ -9,3 +9,4 @@ stringData:
   region: {{ required ".Values.region required" .Values.region }}
 type: Opaque
 {{- end }}
+

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -40,13 +40,13 @@ spec:
             - name: LINODE_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: ccm-linode
-                  key: apiToken
+                  name: {{ .Values.secretRef.name | default "ccm-linode"}}
+                  key: {{ .Values.secretRef.apiTokenRef | default "apiToken"}}
             - name: LINODE_REGION
               valueFrom:
                 secretKeyRef:
-                  name: ccm-linode
-                  key: region
+                  name: {{ .Values.secretRef.name | default "ccm-linode"}}
+                  key: {{ .Values.secretRef.regionRef | default "region"}}
             {{- toYaml .Values.env | nindent 12 }}
       volumes:
         - name: k8s

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -40,14 +40,16 @@ spec:
             - name: LINODE_API_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secretRef.name | default "ccm-linode"}}
-                  key: {{ .Values.secretRef.apiTokenRef | default "apiToken"}}
+                  name: {{ if .Values.secretRef }}{{ .Values.secretRef.name | default "ccm-linode" }}{{ else }}"ccm-linode"{{ end }}
+                  key: {{ if .Values.secretRef }}{{ .Values.secretRef.apiTokenRef | default "apiToken" }}{{ else }}"apiToken"{{ end }}
             - name: LINODE_REGION
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secretRef.name | default "ccm-linode"}}
-                  key: {{ .Values.secretRef.regionRef | default "region"}}
+                  name: {{ if .Values.secretRef }}{{ .Values.secretRef.name | default "ccm-linode" }}{{ else }}"ccm-linode"{{ end }}
+                  key: {{ if .Values.secretRef }}{{ .Values.secretRef.regionRef | default "region" }}{{ else }}"region"{{ end }}
+            {{if .Values.env}}
             {{- toYaml .Values.env | nindent 12 }}
+            {{end}}
       volumes:
         - name: k8s
           hostPath:

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,8 +1,14 @@
-# apiToken [Required] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens)
+# apiToken [Required if secretRef is not set] - Must be a Linode APIv4 Personal Access Token with all permissions. (https://cloud.linode.com/profile/tokens)
 apiToken: ""
 
-# region [Required] - Must be a Linode region. (https://api.linode.com/v4/regions)
+# region [Required if secretRef is not set] - Must be a Linode region. (https://api.linode.com/v4/regions)
 region: ""
+
+# Set these values if your APIToken and region are already present in a k8s secret.
+# secretRef:
+#   name: "linode-ccm"
+#   apiTokenRef: "apiToken"
+#   regionRef: "region"
 
 # node-role.kubernetes.io/master - if set true, it deploys the svc on the master node
 nodeSelector:


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

Adding support for passing the LinodeAPIToken and region via secret references instead of raw helm values. This prevents the disclosure of the token in values files when using gitops practices.


1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

