### PR TITLE
Allow specifying Private IP by annotation for VLAN / VPC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Kubernetes Services of type `LoadBalancer` will be served through a [Linode Node
 
 The Linode CCM accepts several annotations which affect the properties of the underlying NodeBalancer deployment.
 
-All of the service annotation names listed below have been shortened for readability.  Each annotation **MUST** be prefixed with `service.beta.kubernetes.io/linode-loadbalancer-`.  The values, such as `http`, are case-sensitive.
+All of the Service annotation names listed below have been shortened for readability.  The values, such as `http`, are case-sensitive.
+
+Each *Service* annotation **MUST** be prefixed with:<br />
+**`service.beta.kubernetes.io/linode-loadbalancer-`**
 
 Annotation (Suffix) | Values | Default | Description
 ---|---|---|---
@@ -80,7 +83,23 @@ Key | Values | Default | Description
 `proxy-protocol` | `none`, `v1`, `v2` | `none` | Specifies whether to use a version of Proxy Protocol on the underlying NodeBalancer. Overwrites `default-proxy-protocol`.
 `tls-secret-name` | string | | Specifies a secret to use for TLS. The secret type should be `kubernetes.io/tls`.
 
-#### Example usage
+### Nodes
+
+Kubernetes Nodes can be configured with the following annotations.
+
+Each *Node* annotation **MUST** be prefixed with:<br />
+**`node.k8s.linode.com/`**
+
+Key | Values | Default | Description
+---|---|---|---
+`private-ip` | `IPv4` | `none` | Specifies the Linode Private IP overriding default detection of the Node InternalIP.<br />When using a [VLAN] or [VPC], the Node InternalIP may not be a Linode Private IP as [required for NodeBalancers] and should be specified.
+
+
+[required for NodeBalancers]: https://www.linode.com/docs/api/nodebalancers/#nodebalancer-create__request-body-schema
+[VLAN]: https://www.linode.com/products/vlan/
+[VPC]: https://www.linode.com/blog/linode/new-betas-coming-to-green-light/
+
+### Example usage
 
 ```yaml
 kind: Service

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -1112,7 +1112,7 @@ func Test_getHealthCheckType(t *testing.T) {
 	}
 }
 
-func Test_getNodeInternalIP(t *testing.T) {
+func Test_getNodePrivateIP(t *testing.T) {
 	testcases := []struct {
 		name    string
 		node    *v1.Node
@@ -1146,11 +1146,30 @@ func Test_getNodeInternalIP(t *testing.T) {
 			},
 			"",
 		},
+		{
+			"node internal ip annotation present",
+			&v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annLinodeNodePrivateIP: "192.168.42.42",
+					},
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    v1.NodeInternalIP,
+							Address: "10.0.1.1",
+						},
+					},
+				},
+			},
+			"192.168.42.42",
+		},
 	}
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			ip := getNodeInternalIP(test.node)
+			ip := getNodePrivateIP(test.node)
 			if ip != test.address {
 				t.Error("unexpected certificate")
 				t.Logf("expected: %q", test.address)


### PR DESCRIPTION
Fixes #111

Kubernetes node internal IP addresses are not necessarily Linode Private IPs, which must be used for NodeBalancers to communicate with a node. This allows specifying the IP with an annotation in such cases.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

### Testing

Manually set the annotation to on dev2-worker-0 to another Linode (that isn't running these services) to prove the change: 

![image](https://github.com/linode/linode-cloud-controller-manager/assets/202230/ef852628-b5aa-49c9-98f7-71be6e9d97ca)

The canonical test would be on a VLAN/VPC cluster, but this seem sufficient.


