### PR TITLE
fix: metadata TTL

### DIFF
--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -53,12 +53,11 @@ type instances struct {
 }
 
 func newInstances(client Client) *instances {
-	var timeout int
+	timeout := 15
 	if raw, ok := os.LookupEnv("LINODE_INSTANCE_CACHE_TTL"); ok {
-		timeout, _ = strconv.Atoi(raw)
-	}
-	if timeout == 0 {
-		timeout = 15
+		if t, _ := strconv.Atoi(raw); t > 0 {
+			timeout = t
+		}
 	}
 
 	return &instances{client, &nodeCache{


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

**BUGFIX:** This code change involves modifying the logic for handling metadata updates for Linode instances in a Kubernetes cluster. Previous behaviour spammed, did redundant work on Create and Update, and every time it was triggered, it pulled the node from the API. This prevents hitting the API too often.

1. **instances.go**:
   - The `timeout` variable is changed to be initialised with a default value of 15.
   - If the environment variable `LINODE_INSTANCE_CACHE_TTL` is set, the timeout is updated accordingly, but now it checks if the parsed value is greater than 0 before updating the `timeout`. This ensures that only positive values are considered valid for the timeout.
1. **node_controller.go**:
   - The `nodeController` structure is extended to include a `sync.RWMutex` for safe concurrent access to shared data.
   - Two new fields, `metadataLastUpdate` and `ttl`, are added to keep track of the last metadata update time and the time-to-live for metadata, respectively.
   - The `timeout` variable is introduced, which defaults to 300 seconds (5 minutes), and it can be overridden by the `LINODE_METADATA_TTL` environment variable.
   - Two new methods, `LastMetadataUpdate` and `SetLastMetadataUpdate`, are added to get and set the last metadata update time for a given node name in a thread safe manner.

   Changes in `handleNodeAdded`:
   - Before attempting to fetch Linode information, it checks the last update time and the TTL to decide whether a fresh metadata update is required.
   - The `SetLastMetadataUpdate` method is called after a successful update to store the current time as the last update time for that node.

   Changes in `Run`:
   - The `UpdateFunc` in the informer is removed. This function was handling updated nodes' metadata, but it's redundant.

In summary, the changes provide better control over the caching mechanism for Linode instance metadata. The introduction of a TTL for metadata and the ability to configure it through environment variables allow for more flexibility and optimisation in handling updates. Additionally, the use of a mutex ensures thread-safe access to shared data in a concurrent environment.