### PR TITLE
fix: set host-uuid correctly on non LKE clusters

### DIFF
--- a/cloud/linode/common.go
+++ b/cloud/linode/common.go
@@ -16,8 +16,12 @@ func (e invalidProviderIDError) Error() string {
 	return fmt.Sprintf("invalid provider ID %q", e.value)
 }
 
+func isLinodeProviderID(providerID string) bool {
+	return strings.HasPrefix(providerID, providerIDPrefix)
+}
+
 func parseProviderID(providerID string) (int, error) {
-	if !strings.HasPrefix(providerID, providerIDPrefix) {
+	if !isLinodeProviderID(providerID) {
 		return 0, invalidProviderIDError{providerID}
 	}
 	id, err := strconv.Atoi(strings.TrimPrefix(providerID, providerIDPrefix))

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -108,7 +108,7 @@ func (i *instances) lookupLinode(ctx context.Context, node *v1.Node) (*linodego.
 	sentry.SetTag(ctx, "provider_id", providerID)
 	sentry.SetTag(ctx, "node_name", node.Name)
 
-	if providerID != "" {
+	if providerID != "" && isLinodeProviderID(providerID){
 		id, err := parseProviderID(providerID)
 		if err != nil {
 			sentry.CaptureError(ctx, err)

--- a/cloud/linode/instances_test.go
+++ b/cloud/linode/instances_test.go
@@ -233,17 +233,6 @@ func TestMalformedProviders(t *testing.T) {
 
 	client := NewMockClient(ctrl)
 
-	t.Run("fails on malformed providerID", func(t *testing.T) {
-		instances := newInstances(client)
-		providerID := "bogus://bogus"
-		node := nodeWithProviderID(providerID)
-		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{}, nil)
-
-		meta, err := instances.InstanceMetadata(ctx, node)
-		assert.ErrorIs(t, err, invalidProviderIDError{providerID})
-		assert.Nil(t, meta)
-	})
-
 	t.Run("fails on non-numeric providerID", func(t *testing.T) {
 		instances := newInstances(client)
 		providerID := providerIDPrefix + "abc"


### PR DESCRIPTION
Fixes a bug where the host-uuid was not set correctly for non-LKE clusters. 

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

