### PR TITLE
Use Go 1.22 HTTP router in fake API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 IMG ?= linode/linode-cloud-controller-manager:canary
 RELEASE_DIR ?= release
-GOLANGCI_LINT_IMG := golangci/golangci-lint:v1.55-alpine
 PLATFORM ?= linux/amd64
 
 export GO111MODULE=on
@@ -26,9 +25,9 @@ vet: fmt
 .PHONY: lint
 lint:
 	docker run --rm -v "$(shell pwd):/var/work:ro" -w /var/work \
-		golangci/golangci-lint:v1.55.2 golangci-lint run -v --timeout=5m
+		golangci/golangci-lint:v1.56.0 golangci-lint run -v --timeout=5m
 	docker run --rm -v "$(shell pwd):/var/work:ro" -w /var/work/e2e \
-		golangci/golangci-lint:v1.55.2 golangci-lint run -v --timeout=5m
+		golangci/golangci-lint:v1.56.0 golangci-lint run -v --timeout=5m
 
 .PHONY: fmt
 fmt:
@@ -36,8 +35,9 @@ fmt:
 
 .PHONY: test
 # we say code is not worth testing unless it's formatted
+# TODO(PR): revert back to go
 test: fmt codegen
-	go test -v -cover ./cloud/... $(TEST_ARGS)
+	go1.22.0 test -v -cover ./cloud/... $(TEST_ARGS)
 
 .PHONY: build-linux
 build-linux: codegen

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -251,26 +251,6 @@ func (f *fakeAPI) setupRoutes() {
 		}
 	})
 
-	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}", func(w http.ResponseWriter, r *http.Request) {
-		delete(f.nb, r.PathValue("nodeBalancerId"))
-		nid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
-		if err != nil {
-			f.t.Fatal(err)
-		}
-
-		for k, c := range f.nbc {
-			if c.NodeBalancerID == nid {
-				delete(f.nbc, k)
-			}
-		}
-
-		for k, n := range f.nbn {
-			if n.NodeBalancerID == nid {
-				delete(f.nbn, k)
-			}
-		}
-	})
-
 	f.mux.HandleFunc("POST /v4/nodebalancers", func(w http.ResponseWriter, r *http.Request) {
 		nbco := linodego.NodeBalancerCreateOptions{}
 		if err := json.NewDecoder(r.Body).Decode(&nbco); err != nil {
@@ -503,6 +483,26 @@ func (f *fakeAPI) setupRoutes() {
 			f.t.Fatal(err)
 		}
 		_, _ = w.Write(resp)
+	})
+
+	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}", func(w http.ResponseWriter, r *http.Request) {
+		delete(f.nb, r.PathValue("nodeBalancerId"))
+		nid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		for k, c := range f.nbc {
+			if c.NodeBalancerID == nid {
+				delete(f.nbc, k)
+			}
+		}
+
+		for k, n := range f.nbn {
+			if n.NodeBalancerID == nid {
+				delete(f.nbn, k)
+			}
+		}
 	})
 
 	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}/configs/{configId}/nodes/{nodeId}", func(w http.ResponseWriter, r *http.Request) {

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -107,10 +107,57 @@ func (f *fakeAPI) setupRoutes() {
 		}
 		rr, _ := json.Marshal(resp)
 		_, _ = w.Write(rr)
-		return
 	})
 
 	f.mux.HandleFunc("GET /v4/nodebalancers/{nodeBalancerId}", func(w http.ResponseWriter, r *http.Request) {
+		nb, found := f.nb[r.PathValue("nodeBalancerId")]
+		if found {
+			rr, _ := json.Marshal(nb)
+			_, _ = w.Write(rr)
+
+		} else {
+			w.WriteHeader(404)
+			resp := linodego.APIError{
+				Errors: []linodego.APIErrorReason{
+					{Reason: "Not Found"},
+				},
+			}
+			rr, _ := json.Marshal(resp)
+			_, _ = w.Write(rr)
+		}
+	})
+
+	f.mux.HandleFunc("GET /v4/nodebalancers/{nodeBalancerId}/firewalls", func(w http.ResponseWriter, r *http.Request) {
+		devID, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		data := linodego.NodeBalancerFirewallsPagedResponse{
+			Data: []linodego.Firewall{},
+			PageOptions: &linodego.PageOptions{
+				Page:    1,
+				Pages:   1,
+				Results: 0,
+			},
+		}
+
+	out:
+		for fwid, devices := range f.fwd {
+			for _, device := range devices {
+				if device.Entity.ID == devID {
+					data.Data = append(data.Data, *f.fw[fwid])
+					data.PageOptions.Results = 1
+					break out
+				}
+			}
+		}
+
+		resp, _ := json.Marshal(data)
+		_, _ = w.Write(resp)
+	})
+
+	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}", func(w http.ResponseWriter, r *http.Request) {
 		delete(f.nb, r.PathValue("nodeBalancerId"))
 		nid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
 		if err != nil {
@@ -209,11 +256,30 @@ func (f *fakeAPI) setupRoutes() {
 		if err != nil {
 			f.t.Fatal(err)
 		}
-		// TODO(PR): these headers are missing in all the responses
-		// maybe add it as middleware?
-		w.Header().Add("Content-Type", "application/json")
 		_, _ = w.Write(resp)
 		return
+	})
+
+	f.mux.HandleFunc("POST /v4/networking/firewalls", func(w http.ResponseWriter, r *http.Request) {
+		fco := linodego.FirewallCreateOptions{}
+		if err := json.NewDecoder(r.Body).Decode(&fco); err != nil {
+			f.t.Fatal(err)
+		}
+
+		firewall := linodego.Firewall{
+			ID:     rand.Intn(9999),
+			Label:  fco.Label,
+			Rules:  fco.Rules,
+			Tags:   fco.Tags,
+			Status: "enabled",
+		}
+
+		f.fw[firewall.ID] = &firewall
+		resp, err := json.Marshal(firewall)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		_, _ = w.Write(resp)
 	})
 
 	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}/configs/{configId}/nodes/{nodeId}", func(w http.ResponseWriter, r *http.Request) {
@@ -293,12 +359,85 @@ func (f *fakeAPI) setupRoutes() {
 		}
 		_, _ = w.Write(resp)
 	})
+
+	f.mux.HandleFunc("PUT /v4/networking/firewalls/{firewallID}/rules", func(w http.ResponseWriter, r *http.Request) {
+		fwrs := new(linodego.FirewallRuleSet)
+		if err := json.NewDecoder(r.Body).Decode(fwrs); err != nil {
+			f.t.Fatal(err)
+		}
+
+		fwID, err := strconv.Atoi(r.PathValue("firewallID"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		if firewall, found := f.fw[fwID]; found {
+			firewall.Rules.Inbound = fwrs.Inbound
+			firewall.Rules.InboundPolicy = fwrs.InboundPolicy
+			// outbound rules do not apply, ignoring.
+			f.fw[fwID] = firewall
+			resp, err := json.Marshal(firewall)
+			if err != nil {
+				f.t.Fatal(err)
+			}
+			_, _ = w.Write(resp)
+			return
+		}
+
+		w.WriteHeader(404)
+		resp := linodego.APIError{
+			Errors: []linodego.APIErrorReason{
+				{Reason: "Not Found"},
+			},
+		}
+		rr, _ := json.Marshal(resp)
+		_, _ = w.Write(rr)
+	})
+
+	f.mux.HandleFunc("PUT /v4/nodebalancers/{nodeBalancerId}", func(w http.ResponseWriter, r *http.Request) {
+		nbuo := new(linodego.NodeBalancerUpdateOptions)
+		if err := json.NewDecoder(r.Body).Decode(nbuo); err != nil {
+			f.t.Fatal(err)
+		}
+		if _, err := strconv.Atoi(r.PathValue("nodeBalancerId")); err != nil {
+			f.t.Fatal(err)
+		}
+
+		if nb, found := f.nb[r.PathValue("nodeBalancerId")]; found {
+			if nbuo.ClientConnThrottle != nil {
+				nb.ClientConnThrottle = *nbuo.ClientConnThrottle
+			}
+			if nbuo.Label != nil {
+				nb.Label = nbuo.Label
+			}
+			if nbuo.Tags != nil {
+				nb.Tags = *nbuo.Tags
+			}
+
+			f.nb[strconv.Itoa(nb.ID)] = nb
+			resp, err := json.Marshal(nb)
+			if err != nil {
+				f.t.Fatal(err)
+			}
+			_, _ = w.Write(resp)
+			return
+		}
+
+		w.WriteHeader(404)
+		resp := linodego.APIError{
+			Errors: []linodego.APIErrorReason{
+				{Reason: "Not Found"},
+			},
+		}
+		rr, _ := json.Marshal(resp)
+		_, _ = w.Write(rr)
+	})
 }
 
 func (f *fakeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Printf("fakeAPI: %s %s", r.Method, r.URL.Path)
-	// 2024/02/08 12:50:04 fakeAPI: POST /v4/networking/firewalls
-	// 2024/02/08 12:50:04 fakeAPI: POST /v4/nodebalancers
+
+	w.Header().Add("Content-Type", "application/json")
 	f.mux.ServeHTTP(w, r)
 	return
 
@@ -482,60 +621,6 @@ func randString() string {
 // 				f.t.Fatal(err)
 // 			}
 // 			_, _ = w.Write(rr)
-// 			return
-// 		}
-
-// 		rx = regexp.MustCompile("/nodebalancers/[0-9]+/firewalls")
-// 		if rx.MatchString(urlPath) {
-// 			id := strings.Split(urlPath, "/")[2]
-// 			devID, err := strconv.Atoi(id)
-// 			if err != nil {
-// 				f.t.Fatal(err)
-// 			}
-
-// 			data := linodego.NodeBalancerFirewallsPagedResponse{
-// 				Data: []linodego.Firewall{},
-// 				PageOptions: &linodego.PageOptions{
-// 					Page:    1,
-// 					Pages:   1,
-// 					Results: 0,
-// 				},
-// 			}
-
-// 		out:
-// 			for fwid, devices := range f.fwd {
-// 				for _, device := range devices {
-// 					if device.Entity.ID == devID {
-// 						data.Data = append(data.Data, *f.fw[fwid])
-// 						data.PageOptions.Results = 1
-// 						break out
-// 					}
-// 				}
-// 			}
-
-// 			resp, _ := json.Marshal(data)
-// 			_, _ = w.Write(resp)
-// 			return
-// 		}
-
-// 		rx, _ = regexp.Compile("/nodebalancers/[0-9]+")
-// 		if rx.MatchString(urlPath) {
-// 			id := filepath.Base(urlPath)
-// 			nb, found := f.nb[id]
-// 			if found {
-// 				rr, _ := json.Marshal(nb)
-// 				_, _ = w.Write(rr)
-
-// 			} else {
-// 				w.WriteHeader(404)
-// 				resp := linodego.APIError{
-// 					Errors: []linodego.APIErrorReason{
-// 						{Reason: "Not Found"},
-// 					},
-// 				}
-// 				rr, _ := json.Marshal(resp)
-// 				_, _ = w.Write(rr)
-// 			}
 // 			return
 // 		}
 // 	case "networking":
@@ -762,77 +847,5 @@ func randString() string {
 // 	} else if strings.Contains(urlPath, "configs") {
 
 // 	} else if strings.Contains(urlPath, "nodebalancer") {
-// 		parts := strings.Split(urlPath[1:], "/")
-// 		nbuo := new(linodego.NodeBalancerUpdateOptions)
-// 		if err := json.NewDecoder(r.Body).Decode(nbuo); err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		if _, err := strconv.Atoi(parts[1]); err != nil {
-// 			f.t.Fatal(err)
-// 		}
 
-// 		if nb, found := f.nb[parts[1]]; found {
-// 			if nbuo.ClientConnThrottle != nil {
-// 				nb.ClientConnThrottle = *nbuo.ClientConnThrottle
-// 			}
-// 			if nbuo.Label != nil {
-// 				nb.Label = nbuo.Label
-// 			}
-// 			if nbuo.Tags != nil {
-// 				nb.Tags = *nbuo.Tags
-// 			}
-
-// 			f.nb[strconv.Itoa(nb.ID)] = nb
-// 			resp, err := json.Marshal(nb)
-// 			if err != nil {
-// 				f.t.Fatal(err)
-// 			}
-// 			_, _ = w.Write(resp)
-// 			return
-// 		}
-
-// 		w.WriteHeader(404)
-// 		resp := linodego.APIError{
-// 			Errors: []linodego.APIErrorReason{
-// 				{Reason: "Not Found"},
-// 			},
-// 		}
-// 		rr, _ := json.Marshal(resp)
-// 		_, _ = w.Write(rr)
-
-// 	} else if strings.Contains(urlPath, "firewalls") {
-// 		// path is networking/firewalls/%d/rules
-// 		parts := strings.Split(urlPath[1:], "/")
-// 		fwrs := new(linodego.FirewallRuleSet)
-// 		if err := json.NewDecoder(r.Body).Decode(fwrs); err != nil {
-// 			f.t.Fatal(err)
-// 		}
-
-// 		fwID, err := strconv.Atoi(parts[2])
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-
-// 		if firewall, found := f.fw[fwID]; found {
-// 			firewall.Rules.Inbound = fwrs.Inbound
-// 			firewall.Rules.InboundPolicy = fwrs.InboundPolicy
-// 			// outbound rules do not apply, ignoring.
-// 			f.fw[fwID] = firewall
-// 			resp, err := json.Marshal(firewall)
-// 			if err != nil {
-// 				f.t.Fatal(err)
-// 			}
-// 			_, _ = w.Write(resp)
-// 			return
-// 		}
-
-// 		w.WriteHeader(404)
-// 		resp := linodego.APIError{
-// 			Errors: []linodego.APIErrorReason{
-// 				{Reason: "Not Found"},
-// 			},
-// 		}
-// 		rr, _ := json.Marshal(resp)
-// 		_, _ = w.Write(rr)
-// 	}
 // }

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -157,6 +157,71 @@ func (f *fakeAPI) setupRoutes() {
 		_, _ = w.Write(resp)
 	})
 
+	// TODO(PR): do we really not care about the NBid?
+	f.mux.HandleFunc("GET /v4/nodebalancers/{nodeBalancerId}/configs", func(w http.ResponseWriter, r *http.Request) {
+		res := 0
+		data := []linodego.NodeBalancerConfig{}
+		filter := r.Header.Get("X-Filter")
+		if filter == "" {
+			for _, n := range f.nbc {
+				data = append(data, *n)
+			}
+		} else {
+			var fs map[string]string
+			err := json.Unmarshal([]byte(filter), &fs)
+			if err != nil {
+				f.t.Fatal(err)
+			}
+			for _, n := range f.nbc {
+				if strconv.Itoa(n.NodeBalancerID) == fs["nodebalancer_id"] {
+					data = append(data, *n)
+				}
+			}
+		}
+		resp := linodego.NodeBalancerConfigsPagedResponse{
+			PageOptions: &linodego.PageOptions{
+				Page:    1,
+				Pages:   1,
+				Results: res,
+			},
+			Data: data,
+		}
+		rr, err := json.Marshal(resp)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		_, _ = w.Write(rr)
+		return
+	})
+
+	f.mux.HandleFunc("GET /v4/nodebalancers/{nodeBalancerId}/configs/{configId}/nodes", func(w http.ResponseWriter, r *http.Request) {
+		res := 0
+		nbcID, err := strconv.Atoi(r.PathValue("configId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		data := []linodego.NodeBalancerNode{}
+
+		for _, nbn := range f.nbn {
+			if nbcID == nbn.ConfigID {
+				data = append(data, *nbn)
+			}
+		}
+
+		resp := linodego.NodeBalancerNodesPagedResponse{
+			PageOptions: &linodego.PageOptions{
+				Page:    1,
+				Pages:   1,
+				Results: res,
+			},
+			Data: data,
+		}
+		rr, _ := json.Marshal(resp)
+		_, _ = w.Write(rr)
+
+	})
+
 	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}", func(w http.ResponseWriter, r *http.Request) {
 		delete(f.nb, r.PathValue("nodeBalancerId"))
 		nid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
@@ -258,6 +323,116 @@ func (f *fakeAPI) setupRoutes() {
 		}
 		_, _ = w.Write(resp)
 		return
+	})
+
+	f.mux.HandleFunc("POST /v4/nodebalancers/{nodeBalancerId}/configs", func(w http.ResponseWriter, r *http.Request) {
+		nbcco := new(linodego.NodeBalancerConfigCreateOptions)
+		if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
+			f.t.Fatal(err)
+		}
+		nbid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		nbcc := linodego.NodeBalancerConfig{
+			ID:             rand.Intn(9999),
+			Port:           nbcco.Port,
+			Protocol:       nbcco.Protocol,
+			ProxyProtocol:  nbcco.ProxyProtocol,
+			Algorithm:      nbcco.Algorithm,
+			Stickiness:     nbcco.Stickiness,
+			Check:          nbcco.Check,
+			CheckInterval:  nbcco.CheckInterval,
+			CheckAttempts:  nbcco.CheckAttempts,
+			CheckPath:      nbcco.CheckPath,
+			CheckBody:      nbcco.CheckBody,
+			CheckPassive:   *nbcco.CheckPassive,
+			CheckTimeout:   nbcco.CheckTimeout,
+			CipherSuite:    nbcco.CipherSuite,
+			NodeBalancerID: nbid,
+			SSLCommonName:  "sslcomonname",
+			SSLFingerprint: "sslfingerprint",
+			SSLCert:        "<REDACTED>",
+			SSLKey:         "<REDACTED>",
+		}
+		f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
+
+		resp, err := json.Marshal(nbcc)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		_, _ = w.Write(resp)
+	})
+
+	f.mux.HandleFunc("POST /v4/nodebalancers/{nodeBalancerId}/configs/{configId}/rebuild", func(w http.ResponseWriter, r *http.Request) {
+		nbcco := new(linodego.NodeBalancerConfigRebuildOptions)
+		if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
+			f.t.Fatal(err)
+		}
+		nbid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		nbcid, err := strconv.Atoi(r.PathValue("configId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		if nbcco.Protocol == "https" {
+			if !strings.Contains(nbcco.SSLCert, "BEGIN CERTIFICATE") {
+				f.t.Fatal("HTTPS port declared without calid ssl cert", nbcco.SSLCert)
+			}
+			if !strings.Contains(nbcco.SSLKey, "BEGIN RSA PRIVATE KEY") {
+				f.t.Fatal("HTTPS port declared without calid ssl key", nbcco.SSLKey)
+			}
+		}
+		nbcc := linodego.NodeBalancerConfig{
+			ID:             nbcid,
+			Port:           nbcco.Port,
+			Protocol:       nbcco.Protocol,
+			ProxyProtocol:  nbcco.ProxyProtocol,
+			Algorithm:      nbcco.Algorithm,
+			Stickiness:     nbcco.Stickiness,
+			Check:          nbcco.Check,
+			CheckInterval:  nbcco.CheckInterval,
+			CheckAttempts:  nbcco.CheckAttempts,
+			CheckPath:      nbcco.CheckPath,
+			CheckBody:      nbcco.CheckBody,
+			CheckPassive:   *nbcco.CheckPassive,
+			CheckTimeout:   nbcco.CheckTimeout,
+			CipherSuite:    nbcco.CipherSuite,
+			NodeBalancerID: nbid,
+			SSLCommonName:  "sslcommonname",
+			SSLFingerprint: "sslfingerprint",
+			SSLCert:        "<REDACTED>",
+			SSLKey:         "<REDACTED>",
+		}
+
+		f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
+		for k, n := range f.nbn {
+			if n.ConfigID == nbcc.ID {
+				delete(f.nbn, k)
+			}
+		}
+
+		for _, n := range nbcco.Nodes {
+			node := linodego.NodeBalancerNode{
+				ID:             rand.Intn(99999),
+				Address:        n.Address,
+				Label:          n.Label,
+				Weight:         n.Weight,
+				Mode:           n.Mode,
+				NodeBalancerID: nbid,
+				ConfigID:       nbcc.ID,
+			}
+			f.nbn[strconv.Itoa(node.ID)] = &node
+		}
+		resp, err := json.Marshal(nbcc)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		_, _ = w.Write(resp)
+
 	})
 
 	f.mux.HandleFunc("POST /v4/networking/firewalls", func(w http.ResponseWriter, r *http.Request) {
@@ -538,35 +713,7 @@ func randString() string {
 // 			}
 // 			return
 // 		}
-// 		rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs/[0-9]+/nodes")
-// 		if rx.MatchString(urlPath) {
-// 			res := 0
-// 			parts := strings.Split(urlPath[1:], "/")
-// 			nbcID, err := strconv.Atoi(parts[3])
-// 			if err != nil {
-// 				f.t.Fatal(err)
-// 			}
 
-// 			data := []linodego.NodeBalancerNode{}
-
-// 			for _, nbn := range f.nbn {
-// 				if nbcID == nbn.ConfigID {
-// 					data = append(data, *nbn)
-// 				}
-// 			}
-
-// 			resp := linodego.NodeBalancerNodesPagedResponse{
-// 				PageOptions: &linodego.PageOptions{
-// 					Page:    1,
-// 					Pages:   1,
-// 					Results: res,
-// 				},
-// 				Data: data,
-// 			}
-// 			rr, _ := json.Marshal(resp)
-// 			_, _ = w.Write(rr)
-// 			return
-// 		}
 // 		rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs/[0-9]+")
 // 		if rx.MatchString(urlPath) {
 // 			id := filepath.Base(urlPath)
@@ -585,42 +732,6 @@ func randString() string {
 // 				rr, _ := json.Marshal(resp)
 // 				_, _ = w.Write(rr)
 // 			}
-// 			return
-// 		}
-// 		rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs")
-// 		if rx.MatchString(urlPath) {
-// 			res := 0
-// 			data := []linodego.NodeBalancerConfig{}
-// 			filter := r.Header.Get("X-Filter")
-// 			if filter == "" {
-// 				for _, n := range f.nbc {
-// 					data = append(data, *n)
-// 				}
-// 			} else {
-// 				var fs map[string]string
-// 				err := json.Unmarshal([]byte(filter), &fs)
-// 				if err != nil {
-// 					f.t.Fatal(err)
-// 				}
-// 				for _, n := range f.nbc {
-// 					if strconv.Itoa(n.NodeBalancerID) == fs["nodebalancer_id"] {
-// 						data = append(data, *n)
-// 					}
-// 				}
-// 			}
-// 			resp := linodego.NodeBalancerConfigsPagedResponse{
-// 				PageOptions: &linodego.PageOptions{
-// 					Page:    1,
-// 					Pages:   1,
-// 					Results: res,
-// 				},
-// 				Data: data,
-// 			}
-// 			rr, err := json.Marshal(resp)
-// 			if err != nil {
-// 				f.t.Fatal(err)
-// 			}
-// 			_, _ = w.Write(rr)
 // 			return
 // 		}
 // 	case "networking":
@@ -661,114 +772,7 @@ func randString() string {
 // 	if tp == "nodebalancers" {
 
 // 	} else if tp == "rebuild" {
-// 		parts := strings.Split(urlPath[1:], "/")
-// 		nbcco := new(linodego.NodeBalancerConfigRebuildOptions)
-// 		if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		nbid, err := strconv.Atoi(parts[1])
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		nbcid, err := strconv.Atoi(parts[3])
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		if nbcco.Protocol == "https" {
-// 			if !strings.Contains(nbcco.SSLCert, "BEGIN CERTIFICATE") {
-// 				f.t.Fatal("HTTPS port declared without calid ssl cert", nbcco.SSLCert)
-// 			}
-// 			if !strings.Contains(nbcco.SSLKey, "BEGIN RSA PRIVATE KEY") {
-// 				f.t.Fatal("HTTPS port declared without calid ssl key", nbcco.SSLKey)
-// 			}
-// 		}
-// 		nbcc := linodego.NodeBalancerConfig{
-// 			ID:             nbcid,
-// 			Port:           nbcco.Port,
-// 			Protocol:       nbcco.Protocol,
-// 			ProxyProtocol:  nbcco.ProxyProtocol,
-// 			Algorithm:      nbcco.Algorithm,
-// 			Stickiness:     nbcco.Stickiness,
-// 			Check:          nbcco.Check,
-// 			CheckInterval:  nbcco.CheckInterval,
-// 			CheckAttempts:  nbcco.CheckAttempts,
-// 			CheckPath:      nbcco.CheckPath,
-// 			CheckBody:      nbcco.CheckBody,
-// 			CheckPassive:   *nbcco.CheckPassive,
-// 			CheckTimeout:   nbcco.CheckTimeout,
-// 			CipherSuite:    nbcco.CipherSuite,
-// 			NodeBalancerID: nbid,
-// 			SSLCommonName:  "sslcommonname",
-// 			SSLFingerprint: "sslfingerprint",
-// 			SSLCert:        "<REDACTED>",
-// 			SSLKey:         "<REDACTED>",
-// 		}
 
-// 		f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
-// 		for k, n := range f.nbn {
-// 			if n.ConfigID == nbcc.ID {
-// 				delete(f.nbn, k)
-// 			}
-// 		}
-
-// 		for _, n := range nbcco.Nodes {
-// 			node := linodego.NodeBalancerNode{
-// 				ID:             rand.Intn(99999),
-// 				Address:        n.Address,
-// 				Label:          n.Label,
-// 				Weight:         n.Weight,
-// 				Mode:           n.Mode,
-// 				NodeBalancerID: nbid,
-// 				ConfigID:       nbcc.ID,
-// 			}
-// 			f.nbn[strconv.Itoa(node.ID)] = &node
-// 		}
-// 		resp, err := json.Marshal(nbcc)
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		_, _ = w.Write(resp)
-// 		return
-// 	} else if tp == "configs" {
-// 		parts := strings.Split(urlPath[1:], "/")
-// 		nbcco := new(linodego.NodeBalancerConfigCreateOptions)
-// 		if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		nbid, err := strconv.Atoi(parts[1])
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-
-// 		nbcc := linodego.NodeBalancerConfig{
-// 			ID:             rand.Intn(9999),
-// 			Port:           nbcco.Port,
-// 			Protocol:       nbcco.Protocol,
-// 			ProxyProtocol:  nbcco.ProxyProtocol,
-// 			Algorithm:      nbcco.Algorithm,
-// 			Stickiness:     nbcco.Stickiness,
-// 			Check:          nbcco.Check,
-// 			CheckInterval:  nbcco.CheckInterval,
-// 			CheckAttempts:  nbcco.CheckAttempts,
-// 			CheckPath:      nbcco.CheckPath,
-// 			CheckBody:      nbcco.CheckBody,
-// 			CheckPassive:   *nbcco.CheckPassive,
-// 			CheckTimeout:   nbcco.CheckTimeout,
-// 			CipherSuite:    nbcco.CipherSuite,
-// 			NodeBalancerID: nbid,
-// 			SSLCommonName:  "sslcomonname",
-// 			SSLFingerprint: "sslfingerprint",
-// 			SSLCert:        "<REDACTED>",
-// 			SSLKey:         "<REDACTED>",
-// 		}
-// 		f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
-
-// 		resp, err := json.Marshal(nbcc)
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		_, _ = w.Write(resp)
-// 		return
 // 	} else if tp == "nodes" {
 // 		parts := strings.Split(urlPath[1:], "/")
 // 		nbnco := new(linodego.NodeBalancerNodeCreateOptions)

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -5,11 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"net"
 	"net/http"
-	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -28,6 +27,7 @@ type fakeAPI struct {
 	fwd map[int]map[int]*linodego.FirewallDevice // map of firewallID -> firewallDeviceID:FirewallDevice
 
 	requests map[fakeRequest]struct{}
+	mux      *http.ServeMux
 }
 
 type fakeRequest struct {
@@ -37,7 +37,7 @@ type fakeRequest struct {
 }
 
 func newFake(t *testing.T) *fakeAPI {
-	return &fakeAPI{
+	fake := &fakeAPI{
 		t:        t,
 		nb:       make(map[string]*linodego.NodeBalancer),
 		nbc:      make(map[string]*linodego.NodeBalancerConfig),
@@ -45,7 +45,10 @@ func newFake(t *testing.T) *fakeAPI {
 		fw:       make(map[int]*linodego.Firewall),
 		fwd:      make(map[int]map[int]*linodego.FirewallDevice),
 		requests: make(map[fakeRequest]struct{}),
+		mux:      http.NewServeMux(),
 	}
+	fake.setupRoutes()
+	return fake
 }
 
 func (f *fakeAPI) ResetRequests() {
@@ -72,346 +75,84 @@ func (f *fakeAPI) didRequestOccur(method, path, body string) bool {
 	return ok
 }
 
-func (f *fakeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	urlPath := r.URL.Path
-
-	if !strings.HasPrefix(urlPath, "/"+apiVersion) {
-		http.Error(w, "not found", http.StatusNotFound)
+func (f *fakeAPI) setupRoutes() {
+	f.mux.HandleFunc("GET /v4/nodebalancers", func(w http.ResponseWriter, r *http.Request) {
+		res := 0
+		data := []linodego.NodeBalancer{}
+		filter := r.Header.Get("X-Filter")
+		if filter == "" {
+			for _, n := range f.nb {
+				data = append(data, *n)
+			}
+		} else {
+			var fs map[string]string
+			err := json.Unmarshal([]byte(filter), &fs)
+			if err != nil {
+				f.t.Fatal(err)
+			}
+			for _, n := range f.nb {
+				if (n.Label != nil && fs["label"] != "" && *n.Label == fs["label"]) ||
+					(fs["ipv4"] != "" && n.IPv4 != nil && *n.IPv4 == fs["ipv4"]) {
+					data = append(data, *n)
+				}
+			}
+		}
+		resp := linodego.NodeBalancersPagedResponse{
+			PageOptions: &linodego.PageOptions{
+				Page:    1,
+				Pages:   1,
+				Results: res,
+			},
+			Data: data,
+		}
+		rr, _ := json.Marshal(resp)
+		_, _ = w.Write(rr)
 		return
-	}
-	urlPath = strings.TrimPrefix(urlPath, "/"+apiVersion)
-	f.recordRequest(r, urlPath)
+	})
 
-	switch r.Method {
-	case "GET":
-		whichAPI := strings.Split(urlPath[1:], "/")
-		switch whichAPI[0] {
-		case "nodebalancers":
-			rx, _ := regexp.Compile("/nodebalancers/[0-9]+/configs/[0-9]+/nodes/[0-9]+")
-			if rx.MatchString(urlPath) {
-				id := filepath.Base(urlPath)
-				nbn, found := f.nbn[id]
-				if found {
-					rr, _ := json.Marshal(nbn)
-					_, _ = w.Write(rr)
+	f.mux.HandleFunc("GET /v4/nodebalancers/{nodeBalancerId}", func(w http.ResponseWriter, r *http.Request) {
+		delete(f.nb, r.PathValue("nodeBalancerId"))
+		nid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
 
-				} else {
-					w.WriteHeader(404)
-					resp := linodego.APIError{
-						Errors: []linodego.APIErrorReason{
-							{Reason: "Not Found"},
-						},
-					}
-					rr, _ := json.Marshal(resp)
-					_, _ = w.Write(rr)
-				}
-				return
-			}
-			rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs/[0-9]+/nodes")
-			if rx.MatchString(urlPath) {
-				res := 0
-				parts := strings.Split(urlPath[1:], "/")
-				nbcID, err := strconv.Atoi(parts[3])
-				if err != nil {
-					f.t.Fatal(err)
-				}
-
-				data := []linodego.NodeBalancerNode{}
-
-				for _, nbn := range f.nbn {
-					if nbcID == nbn.ConfigID {
-						data = append(data, *nbn)
-					}
-				}
-
-				resp := linodego.NodeBalancerNodesPagedResponse{
-					PageOptions: &linodego.PageOptions{
-						Page:    1,
-						Pages:   1,
-						Results: res,
-					},
-					Data: data,
-				}
-				rr, _ := json.Marshal(resp)
-				_, _ = w.Write(rr)
-				return
-			}
-			rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs/[0-9]+")
-			if rx.MatchString(urlPath) {
-				id := filepath.Base(urlPath)
-				nbc, found := f.nbc[id]
-				if found {
-					rr, _ := json.Marshal(nbc)
-					_, _ = w.Write(rr)
-
-				} else {
-					w.WriteHeader(404)
-					resp := linodego.APIError{
-						Errors: []linodego.APIErrorReason{
-							{Reason: "Not Found"},
-						},
-					}
-					rr, _ := json.Marshal(resp)
-					_, _ = w.Write(rr)
-				}
-				return
-			}
-			rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs")
-			if rx.MatchString(urlPath) {
-				res := 0
-				data := []linodego.NodeBalancerConfig{}
-				filter := r.Header.Get("X-Filter")
-				if filter == "" {
-					for _, n := range f.nbc {
-						data = append(data, *n)
-					}
-				} else {
-					var fs map[string]string
-					err := json.Unmarshal([]byte(filter), &fs)
-					if err != nil {
-						f.t.Fatal(err)
-					}
-					for _, n := range f.nbc {
-						if strconv.Itoa(n.NodeBalancerID) == fs["nodebalancer_id"] {
-							data = append(data, *n)
-						}
-					}
-				}
-				resp := linodego.NodeBalancerConfigsPagedResponse{
-					PageOptions: &linodego.PageOptions{
-						Page:    1,
-						Pages:   1,
-						Results: res,
-					},
-					Data: data,
-				}
-				rr, err := json.Marshal(resp)
-				if err != nil {
-					f.t.Fatal(err)
-				}
-				_, _ = w.Write(rr)
-				return
-			}
-
-			rx = regexp.MustCompile("/nodebalancers/[0-9]+/firewalls")
-			if rx.MatchString(urlPath) {
-				id := strings.Split(urlPath, "/")[2]
-				devID, err := strconv.Atoi(id)
-				if err != nil {
-					f.t.Fatal(err)
-				}
-
-				data := linodego.NodeBalancerFirewallsPagedResponse{
-					Data: []linodego.Firewall{},
-					PageOptions: &linodego.PageOptions{
-						Page:    1,
-						Pages:   1,
-						Results: 0,
-					},
-				}
-
-			out:
-				for fwid, devices := range f.fwd {
-					for _, device := range devices {
-						if device.Entity.ID == devID {
-							data.Data = append(data.Data, *f.fw[fwid])
-							data.PageOptions.Results = 1
-							break out
-						}
-					}
-				}
-
-				resp, _ := json.Marshal(data)
-				_, _ = w.Write(resp)
-				return
-			}
-
-			rx, _ = regexp.Compile("/nodebalancers/[0-9]+")
-			if rx.MatchString(urlPath) {
-				id := filepath.Base(urlPath)
-				nb, found := f.nb[id]
-				if found {
-					rr, _ := json.Marshal(nb)
-					_, _ = w.Write(rr)
-
-				} else {
-					w.WriteHeader(404)
-					resp := linodego.APIError{
-						Errors: []linodego.APIErrorReason{
-							{Reason: "Not Found"},
-						},
-					}
-					rr, _ := json.Marshal(resp)
-					_, _ = w.Write(rr)
-				}
-				return
-			}
-			rx, _ = regexp.Compile("/nodebalancers")
-			if rx.MatchString(urlPath) {
-				res := 0
-				data := []linodego.NodeBalancer{}
-				filter := r.Header.Get("X-Filter")
-				if filter == "" {
-					for _, n := range f.nb {
-						data = append(data, *n)
-					}
-				} else {
-					var fs map[string]string
-					err := json.Unmarshal([]byte(filter), &fs)
-					if err != nil {
-						f.t.Fatal(err)
-					}
-					for _, n := range f.nb {
-						if (n.Label != nil && fs["label"] != "" && *n.Label == fs["label"]) ||
-							(fs["ipv4"] != "" && n.IPv4 != nil && *n.IPv4 == fs["ipv4"]) {
-							data = append(data, *n)
-						}
-					}
-				}
-				resp := linodego.NodeBalancersPagedResponse{
-					PageOptions: &linodego.PageOptions{
-						Page:    1,
-						Pages:   1,
-						Results: res,
-					},
-					Data: data,
-				}
-				rr, _ := json.Marshal(resp)
-				_, _ = w.Write(rr)
-				return
-			}
-		case "networking":
-			rx, _ := regexp.Compile("/networking/firewalls/[0-9]+/devices")
-			if rx.MatchString(urlPath) {
-				fwdId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
-				if err != nil {
-					f.t.Fatal(err)
-				}
-
-				firewallDevices, found := f.fwd[fwdId]
-				if found {
-					firewallDeviceList := []linodego.FirewallDevice{}
-					for i := range firewallDevices {
-						firewallDeviceList = append(firewallDeviceList, *firewallDevices[i])
-					}
-					rr, _ := json.Marshal(linodego.FirewallDevicesPagedResponse{
-						PageOptions: &linodego.PageOptions{Page: 1, Pages: 1, Results: len(firewallDeviceList)},
-						Data:        firewallDeviceList,
-					})
-					_, _ = w.Write(rr)
-				} else {
-					w.WriteHeader(404)
-					resp := linodego.APIError{
-						Errors: []linodego.APIErrorReason{
-							{Reason: "Not Found"},
-						},
-					}
-					rr, _ := json.Marshal(resp)
-					_, _ = w.Write(rr)
-				}
-				return
+		for k, c := range f.nbc {
+			if c.NodeBalancerID == nid {
+				delete(f.nbc, k)
 			}
 		}
 
-	case "POST":
-		tp := filepath.Base(urlPath)
-		if tp == "nodebalancers" {
-			nbco := linodego.NodeBalancerCreateOptions{}
-			if err := json.NewDecoder(r.Body).Decode(&nbco); err != nil {
-				f.t.Fatal(err)
+		for k, n := range f.nbn {
+			if n.NodeBalancerID == nid {
+				delete(f.nbn, k)
 			}
+		}
+	})
 
-			ip := net.IPv4(byte(rand.Intn(100)), byte(rand.Intn(100)), byte(rand.Intn(100)), byte(rand.Intn(100))).String()
-			hostname := fmt.Sprintf("nb-%s.%s.linode.com", strings.Replace(ip, ".", "-", 4), strings.ToLower(nbco.Region))
-			nb := linodego.NodeBalancer{
-				ID:       rand.Intn(9999),
-				Label:    nbco.Label,
-				Region:   nbco.Region,
-				IPv4:     &ip,
-				Hostname: &hostname,
-				Tags:     nbco.Tags,
-			}
+	f.mux.HandleFunc("POST /v4/nodebalancers", func(w http.ResponseWriter, r *http.Request) {
+		nbco := linodego.NodeBalancerCreateOptions{}
+		if err := json.NewDecoder(r.Body).Decode(&nbco); err != nil {
+			f.t.Fatal(err)
+		}
 
-			if nbco.ClientConnThrottle != nil {
-				nb.ClientConnThrottle = *nbco.ClientConnThrottle
-			}
-			f.nb[strconv.Itoa(nb.ID)] = &nb
+		ip := net.IPv4(byte(rand.Intn(100)), byte(rand.Intn(100)), byte(rand.Intn(100)), byte(rand.Intn(100))).String()
+		hostname := fmt.Sprintf("nb-%s.%s.linode.com", strings.Replace(ip, ".", "-", 4), strings.ToLower(nbco.Region))
+		nb := linodego.NodeBalancer{
+			ID:       rand.Intn(9999),
+			Label:    nbco.Label,
+			Region:   nbco.Region,
+			IPv4:     &ip,
+			Hostname: &hostname,
+			Tags:     nbco.Tags,
+		}
 
-			for _, nbcco := range nbco.Configs {
-				if nbcco.Protocol == "https" {
-					if !strings.Contains(nbcco.SSLCert, "BEGIN CERTIFICATE") {
-						f.t.Fatal("HTTPS port declared without calid ssl cert", nbcco.SSLCert)
-					}
-					if !strings.Contains(nbcco.SSLKey, "BEGIN RSA PRIVATE KEY") {
-						f.t.Fatal("HTTPS port declared without calid ssl key", nbcco.SSLKey)
-					}
-				}
-				nbc := linodego.NodeBalancerConfig{
-					ID:             rand.Intn(9999),
-					Port:           nbcco.Port,
-					Protocol:       nbcco.Protocol,
-					ProxyProtocol:  nbcco.ProxyProtocol,
-					Algorithm:      nbcco.Algorithm,
-					Stickiness:     nbcco.Stickiness,
-					Check:          nbcco.Check,
-					CheckInterval:  nbcco.CheckInterval,
-					CheckAttempts:  nbcco.CheckAttempts,
-					CheckPath:      nbcco.CheckPath,
-					CheckBody:      nbcco.CheckBody,
-					CheckPassive:   *nbcco.CheckPassive,
-					CheckTimeout:   nbcco.CheckTimeout,
-					CipherSuite:    nbcco.CipherSuite,
-					NodeBalancerID: nb.ID,
-					SSLCommonName:  "sslcommonname",
-					SSLFingerprint: "sslfingerprint",
-					SSLCert:        "<REDACTED>",
-					SSLKey:         "<REDACTED>",
-				}
-				f.nbc[strconv.Itoa(nbc.ID)] = &nbc
+		if nbco.ClientConnThrottle != nil {
+			nb.ClientConnThrottle = *nbco.ClientConnThrottle
+		}
+		f.nb[strconv.Itoa(nb.ID)] = &nb
 
-				for _, nbnco := range nbcco.Nodes {
-					nbn := linodego.NodeBalancerNode{
-						ID:             rand.Intn(99999),
-						Address:        nbnco.Address,
-						Label:          nbnco.Label,
-						Weight:         nbnco.Weight,
-						Mode:           nbnco.Mode,
-						NodeBalancerID: nb.ID,
-						ConfigID:       nbc.ID,
-					}
-					f.nbn[strconv.Itoa(nbn.ID)] = &nbn
-				}
-			}
-
-			if nbco.FirewallID != 0 {
-				createFirewallDevice(nbco.FirewallID, f, linodego.FirewallDeviceCreateOptions{
-					ID:   nb.ID,
-					Type: "nodebalancer",
-				})
-			}
-
-			resp, err := json.Marshal(nb)
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			_, _ = w.Write(resp)
-			return
-
-		} else if tp == "rebuild" {
-			parts := strings.Split(urlPath[1:], "/")
-			nbcco := new(linodego.NodeBalancerConfigRebuildOptions)
-			if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
-				f.t.Fatal(err)
-			}
-			nbid, err := strconv.Atoi(parts[1])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			nbcid, err := strconv.Atoi(parts[3])
-			if err != nil {
-				f.t.Fatal(err)
-			}
+		for _, nbcco := range nbco.Configs {
 			if nbcco.Protocol == "https" {
 				if !strings.Contains(nbcco.SSLCert, "BEGIN CERTIFICATE") {
 					f.t.Fatal("HTTPS port declared without calid ssl cert", nbcco.SSLCert)
@@ -420,65 +161,7 @@ func (f *fakeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					f.t.Fatal("HTTPS port declared without calid ssl key", nbcco.SSLKey)
 				}
 			}
-			nbcc := linodego.NodeBalancerConfig{
-				ID:             nbcid,
-				Port:           nbcco.Port,
-				Protocol:       nbcco.Protocol,
-				ProxyProtocol:  nbcco.ProxyProtocol,
-				Algorithm:      nbcco.Algorithm,
-				Stickiness:     nbcco.Stickiness,
-				Check:          nbcco.Check,
-				CheckInterval:  nbcco.CheckInterval,
-				CheckAttempts:  nbcco.CheckAttempts,
-				CheckPath:      nbcco.CheckPath,
-				CheckBody:      nbcco.CheckBody,
-				CheckPassive:   *nbcco.CheckPassive,
-				CheckTimeout:   nbcco.CheckTimeout,
-				CipherSuite:    nbcco.CipherSuite,
-				NodeBalancerID: nbid,
-				SSLCommonName:  "sslcommonname",
-				SSLFingerprint: "sslfingerprint",
-				SSLCert:        "<REDACTED>",
-				SSLKey:         "<REDACTED>",
-			}
-
-			f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
-			for k, n := range f.nbn {
-				if n.ConfigID == nbcc.ID {
-					delete(f.nbn, k)
-				}
-			}
-
-			for _, n := range nbcco.Nodes {
-				node := linodego.NodeBalancerNode{
-					ID:             rand.Intn(99999),
-					Address:        n.Address,
-					Label:          n.Label,
-					Weight:         n.Weight,
-					Mode:           n.Mode,
-					NodeBalancerID: nbid,
-					ConfigID:       nbcc.ID,
-				}
-				f.nbn[strconv.Itoa(node.ID)] = &node
-			}
-			resp, err := json.Marshal(nbcc)
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			_, _ = w.Write(resp)
-			return
-		} else if tp == "configs" {
-			parts := strings.Split(urlPath[1:], "/")
-			nbcco := new(linodego.NodeBalancerConfigCreateOptions)
-			if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
-				f.t.Fatal(err)
-			}
-			nbid, err := strconv.Atoi(parts[1])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-
-			nbcc := linodego.NodeBalancerConfig{
+			nbc := linodego.NodeBalancerConfig{
 				ID:             rand.Intn(9999),
 				Port:           nbcco.Port,
 				Protocol:       nbcco.Protocol,
@@ -493,278 +176,142 @@ func (f *fakeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				CheckPassive:   *nbcco.CheckPassive,
 				CheckTimeout:   nbcco.CheckTimeout,
 				CipherSuite:    nbcco.CipherSuite,
-				NodeBalancerID: nbid,
-				SSLCommonName:  "sslcomonname",
-				SSLFingerprint: "sslfingerprint",
-				SSLCert:        "<REDACTED>",
-				SSLKey:         "<REDACTED>",
-			}
-			f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
-
-			resp, err := json.Marshal(nbcc)
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			_, _ = w.Write(resp)
-			return
-		} else if tp == "nodes" {
-			parts := strings.Split(urlPath[1:], "/")
-			nbnco := new(linodego.NodeBalancerNodeCreateOptions)
-			if err := json.NewDecoder(r.Body).Decode(nbnco); err != nil {
-				f.t.Fatal(err)
-			}
-			nbid, err := strconv.Atoi(parts[1])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			nbcid, err := strconv.Atoi(parts[3])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			nbn := linodego.NodeBalancerNode{
-				ID:             rand.Intn(99999),
-				Address:        nbnco.Address,
-				Label:          nbnco.Label,
-				Status:         "UP",
-				Weight:         nbnco.Weight,
-				Mode:           nbnco.Mode,
-				ConfigID:       nbcid,
-				NodeBalancerID: nbid,
-			}
-			f.nbn[strconv.Itoa(nbn.ID)] = &nbn
-			resp, err := json.Marshal(nbn)
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			_, _ = w.Write(resp)
-			return
-		} else if tp == "firewalls" {
-			fco := linodego.FirewallCreateOptions{}
-			if err := json.NewDecoder(r.Body).Decode(&fco); err != nil {
-				f.t.Fatal(err)
-			}
-
-			firewall := linodego.Firewall{
-				ID:     rand.Intn(9999),
-				Label:  fco.Label,
-				Rules:  fco.Rules,
-				Tags:   fco.Tags,
-				Status: "enabled",
-			}
-
-			f.fw[firewall.ID] = &firewall
-			resp, err := json.Marshal(firewall)
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			_, _ = w.Write(resp)
-			return
-		} else if tp == "devices" {
-			fwId := strings.Split(urlPath, "/")[3]
-			fdco := linodego.FirewallDeviceCreateOptions{}
-			if err := json.NewDecoder(r.Body).Decode(&fdco); err != nil {
-				f.t.Fatal(err)
-			}
-
-			firewallID, err := strconv.Atoi(fwId)
-			if err != nil {
-				f.t.Fatal(err)
-			}
-
-			fwd := createFirewallDevice(firewallID, f, fdco)
-			resp, err := json.Marshal(fwd)
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			_, _ = w.Write(resp)
-			return
-		}
-	case "DELETE":
-		idRaw := filepath.Base(urlPath)
-		id, err := strconv.Atoi(idRaw)
-		if err != nil {
-			f.t.Fatal(err)
-		}
-		if strings.Contains(urlPath, "nodes") {
-			delete(f.nbn, idRaw)
-		} else if strings.Contains(urlPath, "configs") {
-			delete(f.nbc, idRaw)
-
-			for k, n := range f.nbn {
-				if n.ConfigID == id {
-					delete(f.nbn, k)
-				}
-			}
-		} else if strings.Contains(urlPath, "nodebalancers") {
-			delete(f.nb, idRaw)
-
-			for k, c := range f.nbc {
-				if c.NodeBalancerID == id {
-					delete(f.nbc, k)
-				}
-			}
-
-			for k, n := range f.nbn {
-				if n.NodeBalancerID == id {
-					delete(f.nbn, k)
-				}
-			}
-		} else if strings.Contains(urlPath, "devices") {
-			firewallId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-
-			deviceId, err := strconv.Atoi(strings.Split(urlPath, "/")[5])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			delete(f.fwd[firewallId], deviceId)
-		} else if strings.Contains(urlPath, "firewalls") {
-			firewallId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-
-			delete(f.fwd, firewallId)
-			delete(f.fw, firewallId)
-		}
-	case "PUT":
-		if strings.Contains(urlPath, "nodes") {
-			f.t.Fatal("PUT ...nodes is not supported by the mock API")
-		} else if strings.Contains(urlPath, "configs") {
-			parts := strings.Split(urlPath[1:], "/")
-			nbcco := new(linodego.NodeBalancerConfigUpdateOptions)
-			if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
-				f.t.Fatal(err)
-			}
-			nbcid, err := strconv.Atoi(parts[3])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			nbid, err := strconv.Atoi(parts[1])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-
-			nbcc := linodego.NodeBalancerConfig{
-				ID:             nbcid,
-				Port:           nbcco.Port,
-				Protocol:       nbcco.Protocol,
-				ProxyProtocol:  nbcco.ProxyProtocol,
-				Algorithm:      nbcco.Algorithm,
-				Stickiness:     nbcco.Stickiness,
-				Check:          nbcco.Check,
-				CheckInterval:  nbcco.CheckInterval,
-				CheckAttempts:  nbcco.CheckAttempts,
-				CheckPath:      nbcco.CheckPath,
-				CheckBody:      nbcco.CheckBody,
-				CheckPassive:   *nbcco.CheckPassive,
-				CheckTimeout:   nbcco.CheckTimeout,
-				CipherSuite:    nbcco.CipherSuite,
-				NodeBalancerID: nbid,
+				NodeBalancerID: nb.ID,
 				SSLCommonName:  "sslcommonname",
 				SSLFingerprint: "sslfingerprint",
 				SSLCert:        "<REDACTED>",
 				SSLKey:         "<REDACTED>",
 			}
-			f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
+			f.nbc[strconv.Itoa(nbc.ID)] = &nbc
 
-			for _, n := range nbcco.Nodes {
-				node := linodego.NodeBalancerNode{
+			for _, nbnco := range nbcco.Nodes {
+				nbn := linodego.NodeBalancerNode{
 					ID:             rand.Intn(99999),
-					Address:        n.Address,
-					Label:          n.Label,
-					Weight:         n.Weight,
-					Mode:           n.Mode,
-					NodeBalancerID: nbid,
-					ConfigID:       nbcc.ID,
+					Address:        nbnco.Address,
+					Label:          nbnco.Label,
+					Weight:         nbnco.Weight,
+					Mode:           nbnco.Mode,
+					NodeBalancerID: nb.ID,
+					ConfigID:       nbc.ID,
 				}
-
-				f.nbn[strconv.Itoa(node.ID)] = &node
+				f.nbn[strconv.Itoa(nbn.ID)] = &nbn
 			}
-
-			resp, err := json.Marshal(nbcc)
-			if err != nil {
-				f.t.Fatal(err)
-			}
-			_, _ = w.Write(resp)
-			return
-		} else if strings.Contains(urlPath, "nodebalancer") {
-			parts := strings.Split(urlPath[1:], "/")
-			nbuo := new(linodego.NodeBalancerUpdateOptions)
-			if err := json.NewDecoder(r.Body).Decode(nbuo); err != nil {
-				f.t.Fatal(err)
-			}
-			if _, err := strconv.Atoi(parts[1]); err != nil {
-				f.t.Fatal(err)
-			}
-
-			if nb, found := f.nb[parts[1]]; found {
-				if nbuo.ClientConnThrottle != nil {
-					nb.ClientConnThrottle = *nbuo.ClientConnThrottle
-				}
-				if nbuo.Label != nil {
-					nb.Label = nbuo.Label
-				}
-				if nbuo.Tags != nil {
-					nb.Tags = *nbuo.Tags
-				}
-
-				f.nb[strconv.Itoa(nb.ID)] = nb
-				resp, err := json.Marshal(nb)
-				if err != nil {
-					f.t.Fatal(err)
-				}
-				_, _ = w.Write(resp)
-				return
-			}
-
-			w.WriteHeader(404)
-			resp := linodego.APIError{
-				Errors: []linodego.APIErrorReason{
-					{Reason: "Not Found"},
-				},
-			}
-			rr, _ := json.Marshal(resp)
-			_, _ = w.Write(rr)
-
-		} else if strings.Contains(urlPath, "firewalls") {
-			// path is networking/firewalls/%d/rules
-			parts := strings.Split(urlPath[1:], "/")
-			fwrs := new(linodego.FirewallRuleSet)
-			if err := json.NewDecoder(r.Body).Decode(fwrs); err != nil {
-				f.t.Fatal(err)
-			}
-
-			fwID, err := strconv.Atoi(parts[2])
-			if err != nil {
-				f.t.Fatal(err)
-			}
-
-			if firewall, found := f.fw[fwID]; found {
-				firewall.Rules.Inbound = fwrs.Inbound
-				firewall.Rules.InboundPolicy = fwrs.InboundPolicy
-				// outbound rules do not apply, ignoring.
-				f.fw[fwID] = firewall
-				resp, err := json.Marshal(firewall)
-				if err != nil {
-					f.t.Fatal(err)
-				}
-				_, _ = w.Write(resp)
-				return
-			}
-
-			w.WriteHeader(404)
-			resp := linodego.APIError{
-				Errors: []linodego.APIErrorReason{
-					{Reason: "Not Found"},
-				},
-			}
-			rr, _ := json.Marshal(resp)
-			_, _ = w.Write(rr)
 		}
+
+		if nbco.FirewallID != 0 {
+			createFirewallDevice(nbco.FirewallID, f, linodego.FirewallDeviceCreateOptions{
+				ID:   nb.ID,
+				Type: "nodebalancer",
+			})
+		}
+
+		resp, err := json.Marshal(nb)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		// TODO(PR): these headers are missing in all the responses
+		// maybe add it as middleware?
+		w.Header().Add("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+		return
+	})
+
+	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}/configs/{configId}/nodes/{nodeId}", func(w http.ResponseWriter, r *http.Request) {
+		delete(f.nbn, r.PathValue("nodeId"))
+	})
+
+	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}/configs/{configId}", func(w http.ResponseWriter, r *http.Request) {
+		delete(f.nbc, r.PathValue("configId"))
+
+		cid, err := strconv.Atoi(r.PathValue("configId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		for k, n := range f.nbn {
+			if n.ConfigID == cid {
+				delete(f.nbn, k)
+			}
+		}
+	})
+
+	f.mux.HandleFunc("PUT /v4/nodebalancers/{nodeBalancerId}/configs/{configId}", func(w http.ResponseWriter, r *http.Request) {
+		// TODO(PR): reimplement all of this
+		nbcco := new(linodego.NodeBalancerConfigUpdateOptions)
+		if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
+			f.t.Fatal(err)
+		}
+		nbcid, err := strconv.Atoi(r.PathValue("configId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		nbid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		nbcc := linodego.NodeBalancerConfig{
+			ID:             nbcid,
+			Port:           nbcco.Port,
+			Protocol:       nbcco.Protocol,
+			ProxyProtocol:  nbcco.ProxyProtocol,
+			Algorithm:      nbcco.Algorithm,
+			Stickiness:     nbcco.Stickiness,
+			Check:          nbcco.Check,
+			CheckInterval:  nbcco.CheckInterval,
+			CheckAttempts:  nbcco.CheckAttempts,
+			CheckPath:      nbcco.CheckPath,
+			CheckBody:      nbcco.CheckBody,
+			CheckPassive:   *nbcco.CheckPassive,
+			CheckTimeout:   nbcco.CheckTimeout,
+			CipherSuite:    nbcco.CipherSuite,
+			NodeBalancerID: nbid,
+			SSLCommonName:  "sslcommonname",
+			SSLFingerprint: "sslfingerprint",
+			SSLCert:        "<REDACTED>",
+			SSLKey:         "<REDACTED>",
+		}
+		f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
+
+		for _, n := range nbcco.Nodes {
+			node := linodego.NodeBalancerNode{
+				ID:             rand.Intn(99999),
+				Address:        n.Address,
+				Label:          n.Label,
+				Weight:         n.Weight,
+				Mode:           n.Mode,
+				NodeBalancerID: nbid,
+				ConfigID:       nbcc.ID,
+			}
+
+			f.nbn[strconv.Itoa(node.ID)] = &node
+		}
+
+		resp, err := json.Marshal(nbcc)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		_, _ = w.Write(resp)
+	})
+}
+
+func (f *fakeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Printf("fakeAPI: %s %s", r.Method, r.URL.Path)
+	// 2024/02/08 12:50:04 fakeAPI: POST /v4/networking/firewalls
+	// 2024/02/08 12:50:04 fakeAPI: POST /v4/nodebalancers
+	f.mux.ServeHTTP(w, r)
+	return
+
+	w.Header().Set("Content-Type", "application/json")
+	urlPath := r.URL.Path
+
+	// TODO(PR): consider removing all this
+	if !strings.HasPrefix(urlPath, "/"+apiVersion) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
 	}
+	urlPath = strings.TrimPrefix(urlPath, "/"+apiVersion)
+	f.recordRequest(r, urlPath)
 }
 
 func createFirewallDevice(fwId int, f *fakeAPI, fdco linodego.FirewallDeviceCreateOptions) linodego.FirewallDevice {
@@ -791,3 +338,501 @@ func randString() string {
 	}
 	return string(b)
 }
+
+// f.mux.HandleFunc("DELETE /v4/foobar", func(w http.ResponseWriter, r *http.Request) {
+// 	idRaw := filepath.Base(urlPath)
+// 	id, err := strconv.Atoi(idRaw)
+// 	if err != nil {
+// 		f.t.Fatal(err)
+// 	}
+// 	if strings.Contains(urlPath, "nodes") {
+
+// 	} else if strings.Contains(urlPath, "configs") {
+
+// 	} else if strings.Contains(urlPath, "nodebalancers") {
+
+// 		// TODO(PR): couldn't find these endpoints
+// 	} else if strings.Contains(urlPath, "devices") {
+// 		firewallId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		deviceId, err := strconv.Atoi(strings.Split(urlPath, "/")[5])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		delete(f.fwd[firewallId], deviceId)
+// 	} else if strings.Contains(urlPath, "firewalls") {
+// 		firewallId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		delete(f.fwd, firewallId)
+// 		delete(f.fw, firewallId)
+// 	}
+// })
+
+// switch r.Method {
+// case "GET":
+// 	whichAPI := strings.Split(urlPath[1:], "/")
+// 	switch whichAPI[0] {
+// 	case "nodebalancers":
+// 		rx, _ := regexp.Compile("/nodebalancers/[0-9]+/configs/[0-9]+/nodes/[0-9]+")
+// 		if rx.MatchString(urlPath) {
+// 			id := filepath.Base(urlPath)
+// 			nbn, found := f.nbn[id]
+// 			if found {
+// 				rr, _ := json.Marshal(nbn)
+// 				_, _ = w.Write(rr)
+
+// 			} else {
+// 				w.WriteHeader(404)
+// 				resp := linodego.APIError{
+// 					Errors: []linodego.APIErrorReason{
+// 						{Reason: "Not Found"},
+// 					},
+// 				}
+// 				rr, _ := json.Marshal(resp)
+// 				_, _ = w.Write(rr)
+// 			}
+// 			return
+// 		}
+// 		rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs/[0-9]+/nodes")
+// 		if rx.MatchString(urlPath) {
+// 			res := 0
+// 			parts := strings.Split(urlPath[1:], "/")
+// 			nbcID, err := strconv.Atoi(parts[3])
+// 			if err != nil {
+// 				f.t.Fatal(err)
+// 			}
+
+// 			data := []linodego.NodeBalancerNode{}
+
+// 			for _, nbn := range f.nbn {
+// 				if nbcID == nbn.ConfigID {
+// 					data = append(data, *nbn)
+// 				}
+// 			}
+
+// 			resp := linodego.NodeBalancerNodesPagedResponse{
+// 				PageOptions: &linodego.PageOptions{
+// 					Page:    1,
+// 					Pages:   1,
+// 					Results: res,
+// 				},
+// 				Data: data,
+// 			}
+// 			rr, _ := json.Marshal(resp)
+// 			_, _ = w.Write(rr)
+// 			return
+// 		}
+// 		rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs/[0-9]+")
+// 		if rx.MatchString(urlPath) {
+// 			id := filepath.Base(urlPath)
+// 			nbc, found := f.nbc[id]
+// 			if found {
+// 				rr, _ := json.Marshal(nbc)
+// 				_, _ = w.Write(rr)
+
+// 			} else {
+// 				w.WriteHeader(404)
+// 				resp := linodego.APIError{
+// 					Errors: []linodego.APIErrorReason{
+// 						{Reason: "Not Found"},
+// 					},
+// 				}
+// 				rr, _ := json.Marshal(resp)
+// 				_, _ = w.Write(rr)
+// 			}
+// 			return
+// 		}
+// 		rx, _ = regexp.Compile("/nodebalancers/[0-9]+/configs")
+// 		if rx.MatchString(urlPath) {
+// 			res := 0
+// 			data := []linodego.NodeBalancerConfig{}
+// 			filter := r.Header.Get("X-Filter")
+// 			if filter == "" {
+// 				for _, n := range f.nbc {
+// 					data = append(data, *n)
+// 				}
+// 			} else {
+// 				var fs map[string]string
+// 				err := json.Unmarshal([]byte(filter), &fs)
+// 				if err != nil {
+// 					f.t.Fatal(err)
+// 				}
+// 				for _, n := range f.nbc {
+// 					if strconv.Itoa(n.NodeBalancerID) == fs["nodebalancer_id"] {
+// 						data = append(data, *n)
+// 					}
+// 				}
+// 			}
+// 			resp := linodego.NodeBalancerConfigsPagedResponse{
+// 				PageOptions: &linodego.PageOptions{
+// 					Page:    1,
+// 					Pages:   1,
+// 					Results: res,
+// 				},
+// 				Data: data,
+// 			}
+// 			rr, err := json.Marshal(resp)
+// 			if err != nil {
+// 				f.t.Fatal(err)
+// 			}
+// 			_, _ = w.Write(rr)
+// 			return
+// 		}
+
+// 		rx = regexp.MustCompile("/nodebalancers/[0-9]+/firewalls")
+// 		if rx.MatchString(urlPath) {
+// 			id := strings.Split(urlPath, "/")[2]
+// 			devID, err := strconv.Atoi(id)
+// 			if err != nil {
+// 				f.t.Fatal(err)
+// 			}
+
+// 			data := linodego.NodeBalancerFirewallsPagedResponse{
+// 				Data: []linodego.Firewall{},
+// 				PageOptions: &linodego.PageOptions{
+// 					Page:    1,
+// 					Pages:   1,
+// 					Results: 0,
+// 				},
+// 			}
+
+// 		out:
+// 			for fwid, devices := range f.fwd {
+// 				for _, device := range devices {
+// 					if device.Entity.ID == devID {
+// 						data.Data = append(data.Data, *f.fw[fwid])
+// 						data.PageOptions.Results = 1
+// 						break out
+// 					}
+// 				}
+// 			}
+
+// 			resp, _ := json.Marshal(data)
+// 			_, _ = w.Write(resp)
+// 			return
+// 		}
+
+// 		rx, _ = regexp.Compile("/nodebalancers/[0-9]+")
+// 		if rx.MatchString(urlPath) {
+// 			id := filepath.Base(urlPath)
+// 			nb, found := f.nb[id]
+// 			if found {
+// 				rr, _ := json.Marshal(nb)
+// 				_, _ = w.Write(rr)
+
+// 			} else {
+// 				w.WriteHeader(404)
+// 				resp := linodego.APIError{
+// 					Errors: []linodego.APIErrorReason{
+// 						{Reason: "Not Found"},
+// 					},
+// 				}
+// 				rr, _ := json.Marshal(resp)
+// 				_, _ = w.Write(rr)
+// 			}
+// 			return
+// 		}
+// 	case "networking":
+// 		rx, _ := regexp.Compile("/networking/firewalls/[0-9]+/devices")
+// 		if rx.MatchString(urlPath) {
+// 			fwdId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
+// 			if err != nil {
+// 				f.t.Fatal(err)
+// 			}
+
+// 			firewallDevices, found := f.fwd[fwdId]
+// 			if found {
+// 				firewallDeviceList := []linodego.FirewallDevice{}
+// 				for i := range firewallDevices {
+// 					firewallDeviceList = append(firewallDeviceList, *firewallDevices[i])
+// 				}
+// 				rr, _ := json.Marshal(linodego.FirewallDevicesPagedResponse{
+// 					PageOptions: &linodego.PageOptions{Page: 1, Pages: 1, Results: len(firewallDeviceList)},
+// 					Data:        firewallDeviceList,
+// 				})
+// 				_, _ = w.Write(rr)
+// 			} else {
+// 				w.WriteHeader(404)
+// 				resp := linodego.APIError{
+// 					Errors: []linodego.APIErrorReason{
+// 						{Reason: "Not Found"},
+// 					},
+// 				}
+// 				rr, _ := json.Marshal(resp)
+// 				_, _ = w.Write(rr)
+// 			}
+// 			return
+// 		}
+// 	}
+
+// case "POST":
+// 	tp := filepath.Base(urlPath)
+// 	if tp == "nodebalancers" {
+
+// 	} else if tp == "rebuild" {
+// 		parts := strings.Split(urlPath[1:], "/")
+// 		nbcco := new(linodego.NodeBalancerConfigRebuildOptions)
+// 		if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		nbid, err := strconv.Atoi(parts[1])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		nbcid, err := strconv.Atoi(parts[3])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		if nbcco.Protocol == "https" {
+// 			if !strings.Contains(nbcco.SSLCert, "BEGIN CERTIFICATE") {
+// 				f.t.Fatal("HTTPS port declared without calid ssl cert", nbcco.SSLCert)
+// 			}
+// 			if !strings.Contains(nbcco.SSLKey, "BEGIN RSA PRIVATE KEY") {
+// 				f.t.Fatal("HTTPS port declared without calid ssl key", nbcco.SSLKey)
+// 			}
+// 		}
+// 		nbcc := linodego.NodeBalancerConfig{
+// 			ID:             nbcid,
+// 			Port:           nbcco.Port,
+// 			Protocol:       nbcco.Protocol,
+// 			ProxyProtocol:  nbcco.ProxyProtocol,
+// 			Algorithm:      nbcco.Algorithm,
+// 			Stickiness:     nbcco.Stickiness,
+// 			Check:          nbcco.Check,
+// 			CheckInterval:  nbcco.CheckInterval,
+// 			CheckAttempts:  nbcco.CheckAttempts,
+// 			CheckPath:      nbcco.CheckPath,
+// 			CheckBody:      nbcco.CheckBody,
+// 			CheckPassive:   *nbcco.CheckPassive,
+// 			CheckTimeout:   nbcco.CheckTimeout,
+// 			CipherSuite:    nbcco.CipherSuite,
+// 			NodeBalancerID: nbid,
+// 			SSLCommonName:  "sslcommonname",
+// 			SSLFingerprint: "sslfingerprint",
+// 			SSLCert:        "<REDACTED>",
+// 			SSLKey:         "<REDACTED>",
+// 		}
+
+// 		f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
+// 		for k, n := range f.nbn {
+// 			if n.ConfigID == nbcc.ID {
+// 				delete(f.nbn, k)
+// 			}
+// 		}
+
+// 		for _, n := range nbcco.Nodes {
+// 			node := linodego.NodeBalancerNode{
+// 				ID:             rand.Intn(99999),
+// 				Address:        n.Address,
+// 				Label:          n.Label,
+// 				Weight:         n.Weight,
+// 				Mode:           n.Mode,
+// 				NodeBalancerID: nbid,
+// 				ConfigID:       nbcc.ID,
+// 			}
+// 			f.nbn[strconv.Itoa(node.ID)] = &node
+// 		}
+// 		resp, err := json.Marshal(nbcc)
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		_, _ = w.Write(resp)
+// 		return
+// 	} else if tp == "configs" {
+// 		parts := strings.Split(urlPath[1:], "/")
+// 		nbcco := new(linodego.NodeBalancerConfigCreateOptions)
+// 		if err := json.NewDecoder(r.Body).Decode(nbcco); err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		nbid, err := strconv.Atoi(parts[1])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		nbcc := linodego.NodeBalancerConfig{
+// 			ID:             rand.Intn(9999),
+// 			Port:           nbcco.Port,
+// 			Protocol:       nbcco.Protocol,
+// 			ProxyProtocol:  nbcco.ProxyProtocol,
+// 			Algorithm:      nbcco.Algorithm,
+// 			Stickiness:     nbcco.Stickiness,
+// 			Check:          nbcco.Check,
+// 			CheckInterval:  nbcco.CheckInterval,
+// 			CheckAttempts:  nbcco.CheckAttempts,
+// 			CheckPath:      nbcco.CheckPath,
+// 			CheckBody:      nbcco.CheckBody,
+// 			CheckPassive:   *nbcco.CheckPassive,
+// 			CheckTimeout:   nbcco.CheckTimeout,
+// 			CipherSuite:    nbcco.CipherSuite,
+// 			NodeBalancerID: nbid,
+// 			SSLCommonName:  "sslcomonname",
+// 			SSLFingerprint: "sslfingerprint",
+// 			SSLCert:        "<REDACTED>",
+// 			SSLKey:         "<REDACTED>",
+// 		}
+// 		f.nbc[strconv.Itoa(nbcc.ID)] = &nbcc
+
+// 		resp, err := json.Marshal(nbcc)
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		_, _ = w.Write(resp)
+// 		return
+// 	} else if tp == "nodes" {
+// 		parts := strings.Split(urlPath[1:], "/")
+// 		nbnco := new(linodego.NodeBalancerNodeCreateOptions)
+// 		if err := json.NewDecoder(r.Body).Decode(nbnco); err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		nbid, err := strconv.Atoi(parts[1])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		nbcid, err := strconv.Atoi(parts[3])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		nbn := linodego.NodeBalancerNode{
+// 			ID:             rand.Intn(99999),
+// 			Address:        nbnco.Address,
+// 			Label:          nbnco.Label,
+// 			Status:         "UP",
+// 			Weight:         nbnco.Weight,
+// 			Mode:           nbnco.Mode,
+// 			ConfigID:       nbcid,
+// 			NodeBalancerID: nbid,
+// 		}
+// 		f.nbn[strconv.Itoa(nbn.ID)] = &nbn
+// 		resp, err := json.Marshal(nbn)
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		_, _ = w.Write(resp)
+// 		return
+// 	} else if tp == "firewalls" {
+// 		fco := linodego.FirewallCreateOptions{}
+// 		if err := json.NewDecoder(r.Body).Decode(&fco); err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		firewall := linodego.Firewall{
+// 			ID:     rand.Intn(9999),
+// 			Label:  fco.Label,
+// 			Rules:  fco.Rules,
+// 			Tags:   fco.Tags,
+// 			Status: "enabled",
+// 		}
+
+// 		f.fw[firewall.ID] = &firewall
+// 		resp, err := json.Marshal(firewall)
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		_, _ = w.Write(resp)
+// 		return
+// 	} else if tp == "devices" {
+// 		fwId := strings.Split(urlPath, "/")[3]
+// 		fdco := linodego.FirewallDeviceCreateOptions{}
+// 		if err := json.NewDecoder(r.Body).Decode(&fdco); err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		firewallID, err := strconv.Atoi(fwId)
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		fwd := createFirewallDevice(firewallID, f, fdco)
+// 		resp, err := json.Marshal(fwd)
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		_, _ = w.Write(resp)
+// 		return
+// 	}
+// case "PUT":
+// 	if strings.Contains(urlPath, "nodes") {
+// 		f.t.Fatal("PUT ...nodes is not supported by the mock API")
+// 	} else if strings.Contains(urlPath, "configs") {
+
+// 	} else if strings.Contains(urlPath, "nodebalancer") {
+// 		parts := strings.Split(urlPath[1:], "/")
+// 		nbuo := new(linodego.NodeBalancerUpdateOptions)
+// 		if err := json.NewDecoder(r.Body).Decode(nbuo); err != nil {
+// 			f.t.Fatal(err)
+// 		}
+// 		if _, err := strconv.Atoi(parts[1]); err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		if nb, found := f.nb[parts[1]]; found {
+// 			if nbuo.ClientConnThrottle != nil {
+// 				nb.ClientConnThrottle = *nbuo.ClientConnThrottle
+// 			}
+// 			if nbuo.Label != nil {
+// 				nb.Label = nbuo.Label
+// 			}
+// 			if nbuo.Tags != nil {
+// 				nb.Tags = *nbuo.Tags
+// 			}
+
+// 			f.nb[strconv.Itoa(nb.ID)] = nb
+// 			resp, err := json.Marshal(nb)
+// 			if err != nil {
+// 				f.t.Fatal(err)
+// 			}
+// 			_, _ = w.Write(resp)
+// 			return
+// 		}
+
+// 		w.WriteHeader(404)
+// 		resp := linodego.APIError{
+// 			Errors: []linodego.APIErrorReason{
+// 				{Reason: "Not Found"},
+// 			},
+// 		}
+// 		rr, _ := json.Marshal(resp)
+// 		_, _ = w.Write(rr)
+
+// 	} else if strings.Contains(urlPath, "firewalls") {
+// 		// path is networking/firewalls/%d/rules
+// 		parts := strings.Split(urlPath[1:], "/")
+// 		fwrs := new(linodego.FirewallRuleSet)
+// 		if err := json.NewDecoder(r.Body).Decode(fwrs); err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		fwID, err := strconv.Atoi(parts[2])
+// 		if err != nil {
+// 			f.t.Fatal(err)
+// 		}
+
+// 		if firewall, found := f.fw[fwID]; found {
+// 			firewall.Rules.Inbound = fwrs.Inbound
+// 			firewall.Rules.InboundPolicy = fwrs.InboundPolicy
+// 			// outbound rules do not apply, ignoring.
+// 			f.fw[fwID] = firewall
+// 			resp, err := json.Marshal(firewall)
+// 			if err != nil {
+// 				f.t.Fatal(err)
+// 			}
+// 			_, _ = w.Write(resp)
+// 			return
+// 		}
+
+// 		w.WriteHeader(404)
+// 		resp := linodego.APIError{
+// 			Errors: []linodego.APIErrorReason{
+// 				{Reason: "Not Found"},
+// 			},
+// 		}
+// 		rr, _ := json.Marshal(resp)
+// 		_, _ = w.Write(rr)
+// 	}
+// }

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -683,20 +683,17 @@ func (f *fakeAPI) setupRoutes() {
 func (f *fakeAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Printf("fakeAPI: %s %s", r.Method, r.URL.Path)
 
-	w.Header().Add("Content-Type", "application/json")
-	f.mux.ServeHTTP(w, r)
-	return
-
-	w.Header().Set("Content-Type", "application/json")
-	urlPath := r.URL.Path
-
 	// TODO(PR): consider removing all this
+	urlPath := r.URL.Path
 	if !strings.HasPrefix(urlPath, "/"+apiVersion) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 	urlPath = strings.TrimPrefix(urlPath, "/"+apiVersion)
 	f.recordRequest(r, urlPath)
+
+	w.Header().Add("Content-Type", "application/json")
+	f.mux.ServeHTTP(w, r)
 }
 
 func createFirewallDevice(fwId int, f *fakeAPI, fdco linodego.FirewallDeviceCreateOptions) linodego.FirewallDevice {
@@ -723,6 +720,8 @@ func randString() string {
 	}
 	return string(b)
 }
+
+// TODO(PR): these are outstanding, but I didn't find them in the call graph
 
 // switch r.Method {
 // case "GET":
@@ -811,33 +810,3 @@ func randString() string {
 // 		}
 // 		_, _ = w.Write(resp)
 // 		return
-// 	} else if tp == "firewalls" {
-// 		fco := linodego.FirewallCreateOptions{}
-// 		if err := json.NewDecoder(r.Body).Decode(&fco); err != nil {
-// 			f.t.Fatal(err)
-// 		}
-
-// 		firewall := linodego.Firewall{
-// 			ID:     rand.Intn(9999),
-// 			Label:  fco.Label,
-// 			Rules:  fco.Rules,
-// 			Tags:   fco.Tags,
-// 			Status: "enabled",
-// 		}
-
-// 		f.fw[firewall.ID] = &firewall
-// 		resp, err := json.Marshal(firewall)
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		_, _ = w.Write(resp)
-// 		return
-
-// case "PUT":
-// 	if strings.Contains(urlPath, "nodes") {
-// 		f.t.Fatal("PUT ...nodes is not supported by the mock API")
-// 	} else if strings.Contains(urlPath, "configs") {
-
-// 	} else if strings.Contains(urlPath, "nodebalancer") {
-
-// }

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -222,6 +222,35 @@ func (f *fakeAPI) setupRoutes() {
 
 	})
 
+	f.mux.HandleFunc("GET /v4/networking/firewalls/{firewallId}/devices", func(w http.ResponseWriter, r *http.Request) {
+		fwdId, err := strconv.Atoi(r.PathValue("firewallId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		firewallDevices, found := f.fwd[fwdId]
+		if found {
+			firewallDeviceList := []linodego.FirewallDevice{}
+			for i := range firewallDevices {
+				firewallDeviceList = append(firewallDeviceList, *firewallDevices[i])
+			}
+			rr, _ := json.Marshal(linodego.FirewallDevicesPagedResponse{
+				PageOptions: &linodego.PageOptions{Page: 1, Pages: 1, Results: len(firewallDeviceList)},
+				Data:        firewallDeviceList,
+			})
+			_, _ = w.Write(rr)
+		} else {
+			w.WriteHeader(404)
+			resp := linodego.APIError{
+				Errors: []linodego.APIErrorReason{
+					{Reason: "Not Found"},
+				},
+			}
+			rr, _ := json.Marshal(resp)
+			_, _ = w.Write(rr)
+		}
+	})
+
 	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}", func(w http.ResponseWriter, r *http.Request) {
 		delete(f.nb, r.PathValue("nodeBalancerId"))
 		nid, err := strconv.Atoi(r.PathValue("nodeBalancerId"))
@@ -457,6 +486,25 @@ func (f *fakeAPI) setupRoutes() {
 		_, _ = w.Write(resp)
 	})
 
+	f.mux.HandleFunc("POST /v4/networking/firewalls/{firewallId}/devices", func(w http.ResponseWriter, r *http.Request) {
+		fdco := linodego.FirewallDeviceCreateOptions{}
+		if err := json.NewDecoder(r.Body).Decode(&fdco); err != nil {
+			f.t.Fatal(err)
+		}
+
+		firewallID, err := strconv.Atoi(r.PathValue("firewallId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		fwd := createFirewallDevice(firewallID, f, fdco)
+		resp, err := json.Marshal(fwd)
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		_, _ = w.Write(resp)
+	})
+
 	f.mux.HandleFunc("DELETE /v4/nodebalancers/{nodeBalancerId}/configs/{configId}/nodes/{nodeId}", func(w http.ResponseWriter, r *http.Request) {
 		delete(f.nbn, r.PathValue("nodeId"))
 	})
@@ -474,6 +522,29 @@ func (f *fakeAPI) setupRoutes() {
 				delete(f.nbn, k)
 			}
 		}
+	})
+
+	f.mux.HandleFunc("DELETE /v4/networking/firewalls/{firewallId}", func(w http.ResponseWriter, r *http.Request) {
+		firewallId, err := strconv.Atoi(r.PathValue("firewallId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		delete(f.fwd, firewallId)
+		delete(f.fw, firewallId)
+	})
+
+	f.mux.HandleFunc("DELETE /v4/networking/firewalls/{firewallId}/devices/{deviceId}", func(w http.ResponseWriter, r *http.Request) {
+		firewallId, err := strconv.Atoi(r.PathValue("firewallId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+
+		deviceId, err := strconv.Atoi(r.PathValue("deviceId"))
+		if err != nil {
+			f.t.Fatal(err)
+		}
+		delete(f.fwd[firewallId], deviceId)
 	})
 
 	f.mux.HandleFunc("PUT /v4/nodebalancers/{nodeBalancerId}/configs/{configId}", func(w http.ResponseWriter, r *http.Request) {
@@ -653,41 +724,6 @@ func randString() string {
 	return string(b)
 }
 
-// f.mux.HandleFunc("DELETE /v4/foobar", func(w http.ResponseWriter, r *http.Request) {
-// 	idRaw := filepath.Base(urlPath)
-// 	id, err := strconv.Atoi(idRaw)
-// 	if err != nil {
-// 		f.t.Fatal(err)
-// 	}
-// 	if strings.Contains(urlPath, "nodes") {
-
-// 	} else if strings.Contains(urlPath, "configs") {
-
-// 	} else if strings.Contains(urlPath, "nodebalancers") {
-
-// 		// TODO(PR): couldn't find these endpoints
-// 	} else if strings.Contains(urlPath, "devices") {
-// 		firewallId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-
-// 		deviceId, err := strconv.Atoi(strings.Split(urlPath, "/")[5])
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		delete(f.fwd[firewallId], deviceId)
-// 	} else if strings.Contains(urlPath, "firewalls") {
-// 		firewallId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-
-// 		delete(f.fwd, firewallId)
-// 		delete(f.fw, firewallId)
-// 	}
-// })
-
 // switch r.Method {
 // case "GET":
 // 	whichAPI := strings.Split(urlPath[1:], "/")
@@ -735,36 +771,7 @@ func randString() string {
 // 			return
 // 		}
 // 	case "networking":
-// 		rx, _ := regexp.Compile("/networking/firewalls/[0-9]+/devices")
-// 		if rx.MatchString(urlPath) {
-// 			fwdId, err := strconv.Atoi(strings.Split(urlPath, "/")[3])
-// 			if err != nil {
-// 				f.t.Fatal(err)
-// 			}
 
-// 			firewallDevices, found := f.fwd[fwdId]
-// 			if found {
-// 				firewallDeviceList := []linodego.FirewallDevice{}
-// 				for i := range firewallDevices {
-// 					firewallDeviceList = append(firewallDeviceList, *firewallDevices[i])
-// 				}
-// 				rr, _ := json.Marshal(linodego.FirewallDevicesPagedResponse{
-// 					PageOptions: &linodego.PageOptions{Page: 1, Pages: 1, Results: len(firewallDeviceList)},
-// 					Data:        firewallDeviceList,
-// 				})
-// 				_, _ = w.Write(rr)
-// 			} else {
-// 				w.WriteHeader(404)
-// 				resp := linodego.APIError{
-// 					Errors: []linodego.APIErrorReason{
-// 						{Reason: "Not Found"},
-// 					},
-// 				}
-// 				rr, _ := json.Marshal(resp)
-// 				_, _ = w.Write(rr)
-// 			}
-// 			return
-// 		}
 // 	}
 
 // case "POST":
@@ -825,26 +832,7 @@ func randString() string {
 // 		}
 // 		_, _ = w.Write(resp)
 // 		return
-// 	} else if tp == "devices" {
-// 		fwId := strings.Split(urlPath, "/")[3]
-// 		fdco := linodego.FirewallDeviceCreateOptions{}
-// 		if err := json.NewDecoder(r.Body).Decode(&fdco); err != nil {
-// 			f.t.Fatal(err)
-// 		}
 
-// 		firewallID, err := strconv.Atoi(fwId)
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-
-// 		fwd := createFirewallDevice(firewallID, f, fdco)
-// 		resp, err := json.Marshal(fwd)
-// 		if err != nil {
-// 			f.t.Fatal(err)
-// 		}
-// 		_, _ = w.Write(resp)
-// 		return
-// 	}
 // case "PUT":
 // 	if strings.Contains(urlPath, "nodes") {
 // 		f.t.Fatal("PUT ...nodes is not supported by the mock API")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/linode/linode-cloud-controller-manager
 
-go 1.20
+go 1.22
 
 require (
 	github.com/appscode/go v0.0.0-20200323182826-54e98e09185a


### PR DESCRIPTION
### General:

The Fake API has long been a pain to manage - the routing mechanism within it is bunch of `switch` statements nested in yet another layer of `switch` statements, `string.Split`s, `regexp`s etc.

Drafting for now as I only got tests to pass, I haven't cleaned it up.

---

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

