### PR TITLE
update default CCM node selector and tolerations from master to control-plane

### DIFF
--- a/deploy/ccm-linode-template.yaml
+++ b/deploy/ccm-linode-template.yaml
@@ -77,10 +77,10 @@ spec:
       serviceAccountName: ccm-linode
       nodeSelector:
         # The CCM will only run on a Node labelled as a master, you may want to change this
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
       tolerations:
         # The CCM can run on Nodes tainted as masters
-        - key: "node-role.kubernetes.io/master"
+        - key: "node-role.kubernetes.io/control-plane"
           effect: "NoSchedule"
         # The CCM is a "critical addon"
         - key: "CriticalAddonsOnly"

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -13,7 +13,7 @@ region: ""
 # node-role.kubernetes.io/master - if set true, it deploys the svc on the master node
 nodeSelector:
   # The CCM will only run on a Node labelled as a master, you may want to change this
-  node-role.kubernetes.io/master: ""
+  node-role.kubernetes.io/control-plane: ""
 
 # Image repository must be 'linode/linode-cloud-controller-manager'. The tag can be changed/set to various ccm versions.
 # The pullPolicy is set to Always but can be changed when it is not required to always pull the new image
@@ -28,7 +28,7 @@ namespace: "kube-system"
 # Set of default tolerations
 tolerations:
  # The CCM can run on Nodes tainted as masters
-  - key: "node-role.kubernetes.io/master"
+  - key: "node-role.kubernetes.io/control-plane"
     effect: "NoSchedule"
   # The CCM is a "critical addon"
   - key: "CriticalAddonsOnly"


### PR DESCRIPTION
The selector for the CCM should be updated to account for the [deprecation and removal](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-role-kubernetes-io-master-taint) of the `master` node-role. Currently, this doesn't work out-of-the-box on k8s 1.29 which uses only `node-role.kubernetes.io/control-plane` for control plane nodes.