### PR TITLE
Add route_controller to linode CCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ Users can create CloudFirewall instances, supply their own rules and attach them
 **Note**<br/>
 If the user supplies a firewall-id, and later switches to using an ACL, the CCM will take over the CloudFirewall Instance. To avoid this, delete the service, and re-create it so the original CloudFirewall is left undisturbed.
 
+#### Routes
+When running k8s clusters within VPC, node specific podCIDRs need to be allowed on the VPC interface. Linode CCM comes with route-controller functionality which can be enabled for automatically adding/deleting routes on VPC interfaces. When installing CCM with helm, make sure to specify routeController settings.
+
+##### Example usage in values.yaml
+```yaml
+routeController:
+  vpcName: <name of VPC>
+  clusterCIDR: 10.0.0.0/8
+  configureCloudRoutes: true
+```
+
 ### Nodes
 Kubernetes Nodes can be configured with the following annotations.
 

--- a/cloud/linode/client/client.go
+++ b/cloud/linode/client/client.go
@@ -20,6 +20,7 @@ type Client interface {
 	UpdateInstanceConfigInterface(context.Context, int, int, int, linodego.InstanceConfigInterfaceUpdateOptions) (*linodego.InstanceConfigInterface, error)
 
 	ListVPCs(context.Context, *linodego.ListOptions) ([]linodego.VPC, error)
+	GetVPC(context.Context, int) (*linodego.VPC, error)
 
 	CreateNodeBalancer(context.Context, linodego.NodeBalancerCreateOptions) (*linodego.NodeBalancer, error)
 	GetNodeBalancer(context.Context, int) (*linodego.NodeBalancer, error)

--- a/cloud/linode/client/client.go
+++ b/cloud/linode/client/client.go
@@ -16,6 +16,11 @@ type Client interface {
 	ListInstances(context.Context, *linodego.ListOptions) ([]linodego.Instance, error)
 	GetInstanceIPAddresses(context.Context, int) (*linodego.InstanceIPAddressResponse, error)
 
+	ListInstanceConfigs(context.Context, int, *linodego.ListOptions) ([]linodego.InstanceConfig, error)
+	UpdateInstanceConfigInterface(context.Context, int, int, int, linodego.InstanceConfigInterfaceUpdateOptions) (*linodego.InstanceConfigInterface, error)
+
+	ListVPCs(context.Context, *linodego.ListOptions) ([]linodego.VPC, error)
+
 	CreateNodeBalancer(context.Context, linodego.NodeBalancerCreateOptions) (*linodego.NodeBalancer, error)
 	GetNodeBalancer(context.Context, int) (*linodego.NodeBalancer, error)
 	UpdateNodeBalancer(context.Context, int, linodego.NodeBalancerUpdateOptions) (*linodego.NodeBalancer, error)

--- a/cloud/linode/client/mock_client_test.go
+++ b/cloud/linode/client/mock_client_test.go
@@ -226,6 +226,21 @@ func (mr *MockClientMockRecorder) ListFirewallDevices(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFirewallDevices", reflect.TypeOf((*MockClient)(nil).ListFirewallDevices), arg0, arg1, arg2)
 }
 
+// ListInstanceConfigs mocks base method.
+func (m *MockClient) ListInstanceConfigs(arg0 context.Context, arg1 int, arg2 *linodego.ListOptions) ([]linodego.InstanceConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInstanceConfigs", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]linodego.InstanceConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListInstanceConfigs indicates an expected call of ListInstanceConfigs.
+func (mr *MockClientMockRecorder) ListInstanceConfigs(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceConfigs", reflect.TypeOf((*MockClient)(nil).ListInstanceConfigs), arg0, arg1, arg2)
+}
+
 // ListInstances mocks base method.
 func (m *MockClient) ListInstances(arg0 context.Context, arg1 *linodego.ListOptions) ([]linodego.Instance, error) {
 	m.ctrl.T.Helper()
@@ -286,6 +301,21 @@ func (mr *MockClientMockRecorder) ListNodeBalancers(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeBalancers", reflect.TypeOf((*MockClient)(nil).ListNodeBalancers), arg0, arg1)
 }
 
+// ListVPCs mocks base method.
+func (m *MockClient) ListVPCs(arg0 context.Context, arg1 *linodego.ListOptions) ([]linodego.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListVPCs", arg0, arg1)
+	ret0, _ := ret[0].([]linodego.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListVPCs indicates an expected call of ListVPCs.
+func (mr *MockClientMockRecorder) ListVPCs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVPCs", reflect.TypeOf((*MockClient)(nil).ListVPCs), arg0, arg1)
+}
+
 // RebuildNodeBalancerConfig mocks base method.
 func (m *MockClient) RebuildNodeBalancerConfig(arg0 context.Context, arg1, arg2 int, arg3 linodego.NodeBalancerConfigRebuildOptions) (*linodego.NodeBalancerConfig, error) {
 	m.ctrl.T.Helper()
@@ -314,6 +344,21 @@ func (m *MockClient) UpdateFirewallRules(arg0 context.Context, arg1 int, arg2 li
 func (mr *MockClientMockRecorder) UpdateFirewallRules(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFirewallRules", reflect.TypeOf((*MockClient)(nil).UpdateFirewallRules), arg0, arg1, arg2)
+}
+
+// UpdateInstanceConfigInterface mocks base method.
+func (m *MockClient) UpdateInstanceConfigInterface(arg0 context.Context, arg1, arg2, arg3 int, arg4 linodego.InstanceConfigInterfaceUpdateOptions) (*linodego.InstanceConfigInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateInstanceConfigInterface", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*linodego.InstanceConfigInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateInstanceConfigInterface indicates an expected call of UpdateInstanceConfigInterface.
+func (mr *MockClientMockRecorder) UpdateInstanceConfigInterface(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInstanceConfigInterface", reflect.TypeOf((*MockClient)(nil).UpdateInstanceConfigInterface), arg0, arg1, arg2, arg3, arg4)
 }
 
 // UpdateNodeBalancer mocks base method.

--- a/cloud/linode/client/mock_client_test.go
+++ b/cloud/linode/client/mock_client_test.go
@@ -211,6 +211,21 @@ func (mr *MockClientMockRecorder) GetNodeBalancer(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeBalancer", reflect.TypeOf((*MockClient)(nil).GetNodeBalancer), arg0, arg1)
 }
 
+// GetVPC mocks base method.
+func (m *MockClient) GetVPC(arg0 context.Context, arg1 int) (*linodego.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPC", arg0, arg1)
+	ret0, _ := ret[0].(*linodego.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPC indicates an expected call of GetVPC.
+func (mr *MockClientMockRecorder) GetVPC(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPC", reflect.TypeOf((*MockClient)(nil).GetVPC), arg0, arg1)
+}
+
 // ListFirewallDevices mocks base method.
 func (m *MockClient) ListFirewallDevices(arg0 context.Context, arg1 int, arg2 *linodego.ListOptions) ([]linodego.FirewallDevice, error) {
 	m.ctrl.T.Helper()

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -31,6 +31,10 @@ var Options struct {
 	VPCName               string
 }
 
+// VPCID is set when VPCName options flag is set.
+// We use it to list instances running within the VPC if set
+var VPCID int = 0
+
 type linodeCloud struct {
 	client        client.Client
 	instances     cloudprovider.InstancesV2
@@ -68,6 +72,14 @@ func newCloud() (cloudprovider.Interface, error) {
 
 	if Options.LinodeGoDebug {
 		linodeClient.SetDebug(true)
+	}
+
+	if Options.EnableRouteController && Options.VPCName != "" {
+		id, err := getVPCID(linodeClient, Options.VPCName)
+		if err != nil {
+			return nil, fmt.Errorf("failed finding VPC ID: %w", err)
+		}
+		VPCID = id
 	}
 
 	routes, err := newRoutes(linodeClient)

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -74,7 +74,7 @@ func newCloud() (cloudprovider.Interface, error) {
 		linodeClient.SetDebug(true)
 	}
 
-	if Options.EnableRouteController && Options.VPCName != "" {
+	if Options.VPCName != "" {
 		id, err := getVPCID(linodeClient, Options.VPCName)
 		if err != nil {
 			return nil, fmt.Errorf("failed finding VPC ID: %w", err)

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -1,0 +1,30 @@
+package linode
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCloudRouteControllerDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Setenv("LINODE_API_TOKEN", "dummyapitoken")
+	t.Setenv("LINODE_REGION", "us-east")
+
+	t.Run("should not fail if vpc is empty and routecontroller is disabled", func(t *testing.T) {
+		Options.VPCName = ""
+		Options.EnableRouteController = false
+		_, err := newCloud()
+		assert.NoError(t, err)
+	})
+
+	t.Run("fail if vpcname is empty and routecontroller is enabled", func(t *testing.T) {
+		Options.VPCName = ""
+		Options.EnableRouteController = true
+		_, err := newCloud()
+		assert.Error(t, err)
+	})
+}

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -38,7 +38,7 @@ type nodeCache struct {
 
 // getInstanceIPv4Addresses returns all ipv4 addresses configured on a linode.
 func (nc *nodeCache) getInstanceIPv4Addresses(ctx context.Context, instance linodego.Instance, client client.Client) ([]nodeIP, error) {
-	var ips []nodeIP
+	ips := []nodeIP{}
 
 	// If VPC ID is set, fetch instance config to get VPC specific IP
 	if VPCID != 0 {

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -9,19 +9,70 @@ import (
 	"time"
 
 	"github.com/linode/linodego"
+	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
 
 	"github.com/linode/linode-cloud-controller-manager/cloud/linode/client"
 	"github.com/linode/linode-cloud-controller-manager/sentry"
 )
 
+type nodeIP struct {
+	ip     string
+	ipType v1.NodeAddressType
+}
+
+type linodeInstance struct {
+	instance *linodego.Instance
+	ips      []nodeIP
+}
+
 type nodeCache struct {
 	sync.RWMutex
-	nodes      map[int]*linodego.Instance
+	nodes      map[int]linodeInstance
 	lastUpdate time.Time
 	ttl        time.Duration
+}
+
+// getInstanceIPv4Addresses returns all ipv4 addresses configured on a linode.
+func (nc *nodeCache) getInstanceIPv4Addresses(ctx context.Context, id int, client client.Client) ([]nodeIP, error) {
+	// Retrieve ipaddresses for the linode
+	addresses, err := client.GetInstanceIPAddresses(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []nodeIP
+	if len(addresses.IPv4.Public) != 0 {
+		for _, ip := range addresses.IPv4.Public {
+			ips = append(ips, nodeIP{ip: ip.Address, ipType: v1.NodeExternalIP})
+		}
+	}
+
+	// Retrieve instance configs for the linode
+	configs, err := client.ListInstanceConfigs(ctx, id, &linodego.ListOptions{})
+	if err != nil || len(configs) == 0 {
+		return nil, err
+	}
+
+	// Iterate over interfaces in config and find VPC specific ips
+	for _, iface := range configs[0].Interfaces {
+		if iface.VPCID != nil && iface.IPv4.VPC != "" {
+			ips = append(ips, nodeIP{ip: iface.IPv4.VPC, ipType: v1.NodeInternalIP})
+		}
+	}
+
+	// NOTE: We specifically store VPC ips first so that if they exist, they are
+	//       used as internal ip for the nodes than the private ip
+	if len(addresses.IPv4.Private) != 0 {
+		for _, ip := range addresses.IPv4.Private {
+			ips = append(ips, nodeIP{ip: ip.Address, ipType: v1.NodeInternalIP})
+		}
+	}
+
+	return ips, nil
 }
 
 // refreshInstances conditionally loads all instances from the Linode API and caches them.
@@ -39,11 +90,29 @@ func (nc *nodeCache) refreshInstances(ctx context.Context, client client.Client)
 		return err
 	}
 
-	nc.nodes = make(map[int]*linodego.Instance)
+	nc.nodes = make(map[int]linodeInstance, len(instances))
 
+	mtx := sync.Mutex{}
+	g := new(errgroup.Group)
 	for _, instance := range instances {
 		instance := instance
-		nc.nodes[instance.ID] = &instance
+		g.Go(func() error {
+			addresses, err := nc.getInstanceIPv4Addresses(ctx, instance.ID, client)
+			if err != nil {
+				klog.Errorf("Failed fetching ip addresses for instance id %d. Error: %s", instance.ID, err.Error())
+				return err
+			}
+			// take lock on map so that concurrent writes are safe
+			mtx.Lock()
+			defer mtx.Unlock()
+			node := linodeInstance{instance: &instance, ips: addresses}
+			nc.nodes[instance.ID] = node
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
 	}
 
 	nc.lastUpdate = time.Now()
@@ -64,9 +133,10 @@ func newInstances(client client.Client) *instances {
 			timeout = t
 		}
 	}
+	klog.V(3).Infof("TTL for nodeCache set to %d", timeout)
 
 	return &instances{client, &nodeCache{
-		nodes: make(map[int]*linodego.Instance),
+		nodes: make(map[int]linodeInstance, 0),
 		ttl:   time.Duration(timeout) * time.Second,
 	}}
 }
@@ -83,8 +153,8 @@ func (i *instances) linodeByName(nodeName types.NodeName) (*linodego.Instance, e
 	i.nodeCache.RLock()
 	defer i.nodeCache.RUnlock()
 	for _, node := range i.nodeCache.nodes {
-		if node.Label == string(nodeName) {
-			return node, nil
+		if node.instance.Label == string(nodeName) {
+			return node.instance, nil
 		}
 	}
 
@@ -94,11 +164,24 @@ func (i *instances) linodeByName(nodeName types.NodeName) (*linodego.Instance, e
 func (i *instances) linodeByID(id int) (*linodego.Instance, error) {
 	i.nodeCache.RLock()
 	defer i.nodeCache.RUnlock()
-	instance, ok := i.nodeCache.nodes[id]
+	linodeInstance, ok := i.nodeCache.nodes[id]
 	if !ok {
 		return nil, cloudprovider.InstanceNotFound
 	}
-	return instance, nil
+	return linodeInstance.instance, nil
+}
+
+// listAllInstances returns all instances in nodeCache
+func (i *instances) listAllInstances(ctx context.Context) ([]linodego.Instance, error) {
+	if err := i.nodeCache.refreshInstances(ctx, i.client); err != nil {
+		return nil, err
+	}
+
+	instances := []linodego.Instance{}
+	for _, linodeInstance := range i.nodeCache.nodes {
+		instances = append(instances, *linodeInstance.instance)
+	}
+	return instances, nil
 }
 
 func (i *instances) lookupLinode(ctx context.Context, node *v1.Node) (*linodego.Instance, error) {
@@ -165,7 +248,13 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 		return nil, err
 	}
 
-	if len(linode.IPv4) == 0 {
+	ips, err := i.getLinodeIPv4Addresses(ctx, node)
+	if err != nil {
+		sentry.CaptureError(ctx, err)
+		return nil, err
+	}
+
+	if len(ips) == 0 {
 		err := instanceNoIPAddressesError{linode.ID}
 		sentry.CaptureError(ctx, err)
 		return nil, err
@@ -173,12 +262,8 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 
 	addresses := []v1.NodeAddress{{Type: v1.NodeHostName, Address: linode.Label}}
 
-	for _, ip := range linode.IPv4 {
-		ipType := v1.NodeExternalIP
-		if ip.IsPrivate() {
-			ipType = v1.NodeInternalIP
-		}
-		addresses = append(addresses, v1.NodeAddress{Type: ipType, Address: ip.String()})
+	for _, ip := range ips {
+		addresses = append(addresses, v1.NodeAddress{Type: ip.ipType, Address: ip.ip})
 	}
 
 	// note that Zone is omitted as it's not a thing in Linode
@@ -190,4 +275,24 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 	}
 
 	return meta, nil
+}
+
+func (i *instances) getLinodeIPv4Addresses(ctx context.Context, node *v1.Node) ([]nodeIP, error) {
+	ctx = sentry.SetHubOnContext(ctx)
+	instance, err := i.lookupLinode(ctx, node)
+	if err != nil {
+		sentry.CaptureError(ctx, err)
+		return nil, err
+	}
+
+	i.nodeCache.RLock()
+	defer i.nodeCache.RUnlock()
+	linodeInstance, ok := i.nodeCache.nodes[instance.ID]
+	if !ok || len(linodeInstance.ips) == 0 {
+		err := instanceNoIPAddressesError{instance.ID}
+		sentry.CaptureError(ctx, err)
+		return nil, err
+	}
+
+	return linodeInstance.ips, nil
 }

--- a/cloud/linode/instances_test.go
+++ b/cloud/linode/instances_test.go
@@ -64,6 +64,18 @@ func TestInstanceExists(t *testing.T) {
 				Type:   "g6-standard-2",
 			},
 		}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), 123).Times(1).Return(&linodego.InstanceIPAddressResponse{
+			IPv4: &linodego.InstanceIPv4Response{
+				Public: []*linodego.InstanceIP{
+					{Address: "45.76.101.25"},
+				},
+				Private: []*linodego.InstanceIP{
+					{Address: "192.168.133.65"},
+				},
+			},
+			IPv6: nil,
+		}, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{}, nil)
 
 		exists, err := instances.InstanceExists(ctx, node)
 		assert.NoError(t, err)
@@ -78,6 +90,18 @@ func TestInstanceExists(t *testing.T) {
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: 123, Label: name},
 		}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), 123).Times(1).Return(&linodego.InstanceIPAddressResponse{
+			IPv4: &linodego.InstanceIPv4Response{
+				Public: []*linodego.InstanceIP{
+					{Address: "45.76.101.25"},
+				},
+				Private: []*linodego.InstanceIP{
+					{Address: "192.168.133.65"},
+				},
+			},
+			IPv6: nil,
+		}, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{}, nil)
 
 		exists, err := instances.InstanceExists(ctx, node)
 		assert.NoError(t, err)
@@ -127,13 +151,27 @@ func TestMetadataRetrieval(t *testing.T) {
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: id, Label: name, Type: linodeType, Region: region, IPv4: []*net.IP{&publicIPv4, &privateIPv4}},
 		}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
+			IPv4: &linodego.InstanceIPv4Response{
+				Public: []*linodego.InstanceIP{
+					{Address: "45.76.101.25"},
+				},
+				Private: []*linodego.InstanceIP{
+					{Address: "192.168.133.65"},
+				},
+			},
+			IPv6: nil,
+		}, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
+			{ID: 123456},
+		}, nil)
 
 		meta, err := instances.InstanceMetadata(ctx, node)
 		assert.NoError(t, err)
 		assert.Equal(t, providerIDPrefix+strconv.Itoa(id), meta.ProviderID)
 		assert.Equal(t, region, meta.Region)
 		assert.Equal(t, linodeType, meta.InstanceType)
-		assert.Equal(t, meta.NodeAddresses, []v1.NodeAddress{
+		assert.Equal(t, []v1.NodeAddress{
 			{
 				Type:    v1.NodeHostName,
 				Address: name,
@@ -146,7 +184,7 @@ func TestMetadataRetrieval(t *testing.T) {
 				Type:    v1.NodeInternalIP,
 				Address: privateIPv4.String(),
 			},
-		})
+		}, meta.NodeAddresses)
 	})
 
 	ipTests := []struct {
@@ -197,18 +235,37 @@ func TestMetadataRetrieval(t *testing.T) {
 			node := nodeWithProviderID(providerID)
 
 			ips := make([]*net.IP, 0, len(test.inputIPs))
+			pubIPs := make([]*linodego.InstanceIP, 0)
+			privIPs := make([]*linodego.InstanceIP, 0)
 			for _, ip := range test.inputIPs {
 				parsed := net.ParseIP(ip)
 				if parsed == nil {
 					t.Fatalf("cannot parse %v as an ipv4", ip)
 				}
 				ips = append(ips, &parsed)
+				if parsed.IsPrivate() {
+					privIPs = append(privIPs, &linodego.InstanceIP{Address: ip})
+				} else {
+					pubIPs = append(pubIPs, &linodego.InstanceIP{Address: ip})
+				}
+			}
+
+			ipv4s := &linodego.InstanceIPv4Response{
+				Public:  pubIPs,
+				Private: privIPs,
 			}
 
 			linodeType := "g6-standard-1"
 			region := "us-east"
 			client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 				{ID: id, Label: name, Type: linodeType, Region: region, IPv4: ips},
+			}, nil)
+			client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
+				IPv4: ipv4s,
+				IPv6: nil,
+			}, nil)
+			client.EXPECT().ListInstanceConfigs(gomock.Any(), id, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
+				{ID: 123456},
 			}, nil)
 
 			meta, err := instances.InstanceMetadata(ctx, node)
@@ -281,6 +338,16 @@ func TestInstanceShutdown(t *testing.T) {
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: id, Label: "offline-linode", Status: linodego.InstanceOffline},
 		}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
+			IPv4: &linodego.InstanceIPv4Response{
+				Public:  []*linodego.InstanceIP{},
+				Private: []*linodego.InstanceIP{},
+			},
+			IPv6: nil,
+		}, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), id, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
+			{ID: 123456},
+		}, nil)
 		shutdown, err := instances.InstanceShutdown(ctx, node)
 
 		assert.NoError(t, err)
@@ -294,6 +361,16 @@ func TestInstanceShutdown(t *testing.T) {
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: id, Label: "shutting-down-linode", Status: linodego.InstanceShuttingDown},
 		}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
+			IPv4: &linodego.InstanceIPv4Response{
+				Public:  []*linodego.InstanceIP{},
+				Private: []*linodego.InstanceIP{},
+			},
+			IPv6: nil,
+		}, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), id, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
+			{ID: 123456},
+		}, nil)
 		shutdown, err := instances.InstanceShutdown(ctx, node)
 
 		assert.NoError(t, err)
@@ -306,6 +383,16 @@ func TestInstanceShutdown(t *testing.T) {
 		node := nodeWithProviderID(providerIDPrefix + strconv.Itoa(id))
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: id, Label: "running-linode", Status: linodego.InstanceRunning},
+		}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
+			IPv4: &linodego.InstanceIPv4Response{
+				Public:  []*linodego.InstanceIP{},
+				Private: []*linodego.InstanceIP{},
+			},
+			IPv6: nil,
+		}, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), id, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
+			{ID: 123456},
 		}, nil)
 		shutdown, err := instances.InstanceShutdown(ctx, node)
 

--- a/cloud/linode/instances_test.go
+++ b/cloud/linode/instances_test.go
@@ -64,18 +64,6 @@ func TestInstanceExists(t *testing.T) {
 				Type:   "g6-standard-2",
 			},
 		}, nil)
-		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), 123).Times(1).Return(&linodego.InstanceIPAddressResponse{
-			IPv4: &linodego.InstanceIPv4Response{
-				Public: []*linodego.InstanceIP{
-					{Address: "45.76.101.25"},
-				},
-				Private: []*linodego.InstanceIP{
-					{Address: "192.168.133.65"},
-				},
-			},
-			IPv6: nil,
-		}, nil)
-		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{}, nil)
 
 		exists, err := instances.InstanceExists(ctx, node)
 		assert.NoError(t, err)
@@ -90,18 +78,6 @@ func TestInstanceExists(t *testing.T) {
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: 123, Label: name},
 		}, nil)
-		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), 123).Times(1).Return(&linodego.InstanceIPAddressResponse{
-			IPv4: &linodego.InstanceIPv4Response{
-				Public: []*linodego.InstanceIP{
-					{Address: "45.76.101.25"},
-				},
-				Private: []*linodego.InstanceIP{
-					{Address: "192.168.133.65"},
-				},
-			},
-			IPv6: nil,
-		}, nil)
-		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{}, nil)
 
 		exists, err := instances.InstanceExists(ctx, node)
 		assert.NoError(t, err)
@@ -150,20 +126,6 @@ func TestMetadataRetrieval(t *testing.T) {
 		region := "us-east"
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: id, Label: name, Type: linodeType, Region: region, IPv4: []*net.IP{&publicIPv4, &privateIPv4}},
-		}, nil)
-		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
-			IPv4: &linodego.InstanceIPv4Response{
-				Public: []*linodego.InstanceIP{
-					{Address: "45.76.101.25"},
-				},
-				Private: []*linodego.InstanceIP{
-					{Address: "192.168.133.65"},
-				},
-			},
-			IPv6: nil,
-		}, nil)
-		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
-			{ID: 123456},
 		}, nil)
 
 		meta, err := instances.InstanceMetadata(ctx, node)
@@ -250,22 +212,10 @@ func TestMetadataRetrieval(t *testing.T) {
 				}
 			}
 
-			ipv4s := &linodego.InstanceIPv4Response{
-				Public:  pubIPs,
-				Private: privIPs,
-			}
-
 			linodeType := "g6-standard-1"
 			region := "us-east"
 			client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 				{ID: id, Label: name, Type: linodeType, Region: region, IPv4: ips},
-			}, nil)
-			client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
-				IPv4: ipv4s,
-				IPv6: nil,
-			}, nil)
-			client.EXPECT().ListInstanceConfigs(gomock.Any(), id, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
-				{ID: 123456},
 			}, nil)
 
 			meta, err := instances.InstanceMetadata(ctx, node)
@@ -338,16 +288,6 @@ func TestInstanceShutdown(t *testing.T) {
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: id, Label: "offline-linode", Status: linodego.InstanceOffline},
 		}, nil)
-		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
-			IPv4: &linodego.InstanceIPv4Response{
-				Public:  []*linodego.InstanceIP{},
-				Private: []*linodego.InstanceIP{},
-			},
-			IPv6: nil,
-		}, nil)
-		client.EXPECT().ListInstanceConfigs(gomock.Any(), id, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
-			{ID: 123456},
-		}, nil)
 		shutdown, err := instances.InstanceShutdown(ctx, node)
 
 		assert.NoError(t, err)
@@ -361,16 +301,6 @@ func TestInstanceShutdown(t *testing.T) {
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: id, Label: "shutting-down-linode", Status: linodego.InstanceShuttingDown},
 		}, nil)
-		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
-			IPv4: &linodego.InstanceIPv4Response{
-				Public:  []*linodego.InstanceIP{},
-				Private: []*linodego.InstanceIP{},
-			},
-			IPv6: nil,
-		}, nil)
-		client.EXPECT().ListInstanceConfigs(gomock.Any(), id, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
-			{ID: 123456},
-		}, nil)
 		shutdown, err := instances.InstanceShutdown(ctx, node)
 
 		assert.NoError(t, err)
@@ -383,16 +313,6 @@ func TestInstanceShutdown(t *testing.T) {
 		node := nodeWithProviderID(providerIDPrefix + strconv.Itoa(id))
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
 			{ID: id, Label: "running-linode", Status: linodego.InstanceRunning},
-		}, nil)
-		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), id).Times(1).Return(&linodego.InstanceIPAddressResponse{
-			IPv4: &linodego.InstanceIPv4Response{
-				Public:  []*linodego.InstanceIP{},
-				Private: []*linodego.InstanceIP{},
-			},
-			IPv6: nil,
-		}, nil)
-		client.EXPECT().ListInstanceConfigs(gomock.Any(), id, gomock.Any()).Times(1).Return([]linodego.InstanceConfig{
-			{ID: 123456},
 		}, nil)
 		shutdown, err := instances.InstanceShutdown(ctx, node)
 

--- a/cloud/linode/instances_test.go
+++ b/cloud/linode/instances_test.go
@@ -197,19 +197,12 @@ func TestMetadataRetrieval(t *testing.T) {
 			node := nodeWithProviderID(providerID)
 
 			ips := make([]*net.IP, 0, len(test.inputIPs))
-			pubIPs := make([]*linodego.InstanceIP, 0)
-			privIPs := make([]*linodego.InstanceIP, 0)
 			for _, ip := range test.inputIPs {
 				parsed := net.ParseIP(ip)
 				if parsed == nil {
 					t.Fatalf("cannot parse %v as an ipv4", ip)
 				}
 				ips = append(ips, &parsed)
-				if parsed.IsPrivate() {
-					privIPs = append(privIPs, &linodego.InstanceIP{Address: ip})
-				} else {
-					pubIPs = append(pubIPs, &linodego.InstanceIP{Address: ip})
-				}
 			}
 
 			linodeType := "g6-standard-1"

--- a/cloud/linode/mock_client_test.go
+++ b/cloud/linode/mock_client_test.go
@@ -18,6 +18,11 @@ type MockClient struct {
 	recorder *MockClientMockRecorder
 }
 
+// GetVPC implements client.Client.
+func (m *MockClient) GetVPC(context.Context, int) (*linodego.VPC, error) {
+	panic("unimplemented")
+}
+
 // MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient

--- a/cloud/linode/mock_client_test.go
+++ b/cloud/linode/mock_client_test.go
@@ -18,9 +18,19 @@ type MockClient struct {
 	recorder *MockClientMockRecorder
 }
 
-// GetVPC implements client.Client.
-func (m *MockClient) GetVPC(context.Context, int) (*linodego.VPC, error) {
-	panic("unimplemented")
+// GetVPC mocks base method.
+func (m *MockClient) GetVPC(arg0 context.Context, arg1 int) (*linodego.VPC, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPC", arg0, arg1)
+	ret0, _ := ret[0].(*linodego.VPC)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPC indicates an expected call of GetVPC.
+func (mr *MockClientMockRecorder) GetVPC(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPC", reflect.TypeOf((*MockClient)(nil).GetVPC), arg0, arg1)
 }
 
 // MockClientMockRecorder is the mock recorder for MockClient.

--- a/cloud/linode/route_controller.go
+++ b/cloud/linode/route_controller.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/linode/linodego"
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,17 +35,25 @@ func (rc *routeCache) refreshRoutes(ctx context.Context, client client.Client) e
 		return nil
 	}
 
-	instances, err := client.ListInstances(ctx, nil)
+	// Get VPC details to find instances within the VPC
+	resp, err := client.GetVPC(ctx, VPCID)
 	if err != nil {
 		return err
 	}
 
-	rc.routes = make(map[int][]linodego.InstanceConfig, len(instances))
+	vpcNodes := []int{}
+	for _, subnet := range resp.Subnets {
+		for _, linode := range subnet.Linodes {
+			vpcNodes = append(vpcNodes, linode.ID)
+		}
+	}
+
+	rc.routes = make(map[int][]linodego.InstanceConfig, len(vpcNodes))
 
 	mtx := sync.Mutex{}
 	g := new(errgroup.Group)
-	for _, instance := range instances {
-		id := instance.ID
+	for _, id := range vpcNodes {
+		id := id
 		g.Go(func() error {
 			configs, err := client.ListInstanceConfigs(ctx, id, &linodego.ListOptions{})
 			if err != nil {
@@ -84,17 +92,8 @@ func newRoutes(client client.Client) (cloudprovider.Routes, error) {
 	}
 	klog.V(3).Infof("TTL for routeCache set to %d", timeout)
 
-	vpcid := 0
-	if Options.EnableRouteController {
-		id, err := getVPCID(client, Options.VPCName)
-		if err != nil {
-			return nil, err
-		}
-		vpcid = id
-	}
-
 	return &routes{
-		vpcid:     vpcid,
+		vpcid:     VPCID,
 		client:    client,
 		instances: newInstances(client),
 		routeCache: &routeCache{

--- a/cloud/linode/route_controller.go
+++ b/cloud/linode/route_controller.go
@@ -1,0 +1,254 @@
+package linode
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/linode/linodego"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/exp/slices"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
+
+	"github.com/linode/linode-cloud-controller-manager/cloud/linode/client"
+)
+
+type routeCache struct {
+	sync.RWMutex
+	routes     map[int][]linodego.InstanceConfig
+	lastUpdate time.Time
+	ttl        time.Duration
+}
+
+func (rc *routeCache) refreshRoutes(ctx context.Context, client client.Client) error {
+	rc.Lock()
+	defer rc.Unlock()
+
+	if time.Since(rc.lastUpdate) < rc.ttl {
+		return nil
+	}
+
+	instances, err := client.ListInstances(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	rc.routes = make(map[int][]linodego.InstanceConfig, len(instances))
+
+	mtx := sync.Mutex{}
+	g := new(errgroup.Group)
+	for _, instance := range instances {
+		id := instance.ID
+		g.Go(func() error {
+			configs, err := client.ListInstanceConfigs(ctx, id, &linodego.ListOptions{})
+			if err != nil {
+				klog.Errorf("Failed fetching instance configs for instance id %d. Error: %s", id, err.Error())
+				return err
+			}
+			// take lock on map so that concurrent writes are safe
+			mtx.Lock()
+			defer mtx.Unlock()
+			rc.routes[id] = configs
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	rc.lastUpdate = time.Now()
+	return nil
+}
+
+type routes struct {
+	vpcid      int
+	client     client.Client
+	instances  *instances
+	routeCache *routeCache
+}
+
+func newRoutes(client client.Client) (cloudprovider.Routes, error) {
+	timeout := 60
+	if raw, ok := os.LookupEnv("LINODE_ROUTES_CACHE_TTL"); ok {
+		if t, _ := strconv.Atoi(raw); t > 0 {
+			timeout = t
+		}
+	}
+	klog.V(3).Infof("TTL for routeCache set to %d", timeout)
+
+	vpcid := 0
+	if Options.EnableRouteController {
+		id, err := getVPCID(client, Options.VPCName)
+		if err != nil {
+			return nil, err
+		}
+		vpcid = id
+	}
+
+	return &routes{
+		vpcid:     vpcid,
+		client:    client,
+		instances: newInstances(client),
+		routeCache: &routeCache{
+			routes: make(map[int][]linodego.InstanceConfig, 0),
+			ttl:    time.Duration(timeout) * time.Second,
+		},
+	}, nil
+}
+
+// instanceConfigsByID returns InstanceConfigs for given instance id
+func (r *routes) instanceConfigsByID(id int) ([]linodego.InstanceConfig, error) {
+	r.routeCache.RLock()
+	defer r.routeCache.RUnlock()
+	instanceConfigs, ok := r.routeCache.routes[id]
+	if !ok {
+		return nil, fmt.Errorf("no configs found for instance %d", id)
+	}
+	return instanceConfigs, nil
+}
+
+// getInstanceConfigs returns InstanceConfigs for given instance id
+// It refreshes routeCache if it has expired
+func (r *routes) getInstanceConfigs(ctx context.Context, id int) ([]linodego.InstanceConfig, error) {
+	if err := r.routeCache.refreshRoutes(ctx, r.client); err != nil {
+		return nil, err
+	}
+
+	return r.instanceConfigsByID(id)
+}
+
+// getInstanceFromName returns linode instance with given name if it exists
+func (r *routes) getInstanceFromName(ctx context.Context, name string) (*linodego.Instance, error) {
+	// create node object
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	// fetch instance with specified node name
+	instance, err := r.instances.lookupLinode(ctx, node)
+	if err != nil {
+		klog.Errorf("failed getting linode %s", name)
+		return nil, err
+	}
+	return instance, nil
+}
+
+// CreateRoute adds route's subnet to ip_ranges of target node's VPC interface
+func (r *routes) CreateRoute(ctx context.Context, clusterName string, nameHint string, route *cloudprovider.Route) error {
+	instance, err := r.getInstanceFromName(ctx, string(route.TargetNode))
+	if err != nil {
+		return err
+	}
+
+	// fetch instance configs
+	configs, err := r.getInstanceConfigs(ctx, instance.ID)
+	if err != nil {
+		return err
+	}
+
+	// find VPC interface and add route to it
+	for _, iface := range configs[0].Interfaces {
+		if iface.VPCID == nil || r.vpcid != *iface.VPCID || iface.IPv4.VPC == "" {
+			continue
+		}
+
+		if slices.Contains(iface.IPRanges, route.DestinationCIDR) {
+			klog.V(4).Infof("Route already exists for node %s", route.TargetNode)
+			return nil
+		}
+
+		ipRanges := append(iface.IPRanges, route.DestinationCIDR)
+		interfaceUpdateOptions := linodego.InstanceConfigInterfaceUpdateOptions{
+			IPRanges: ipRanges,
+		}
+		resp, err := r.client.UpdateInstanceConfigInterface(ctx, instance.ID, configs[0].ID, iface.ID, interfaceUpdateOptions)
+		if err != nil {
+			return err
+		}
+		klog.V(4).Infof("Added routes for node %s. Current routes: %v", route.TargetNode, resp.IPRanges)
+		return nil
+	}
+
+	return fmt.Errorf("unable to add route %s for node %s. no valid interface found", route.DestinationCIDR, route.TargetNode)
+}
+
+// DeleteRoute removes route's subnet from ip_ranges of target node's VPC interface
+func (r *routes) DeleteRoute(ctx context.Context, clusterName string, route *cloudprovider.Route) error {
+	instance, err := r.getInstanceFromName(ctx, string(route.TargetNode))
+	if err != nil {
+		return err
+	}
+
+	configs, err := r.getInstanceConfigs(ctx, instance.ID)
+	if err != nil {
+		return err
+	}
+
+	for _, iface := range configs[0].Interfaces {
+		if iface.VPCID == nil || r.vpcid != *iface.VPCID || iface.IPv4.VPC == "" {
+			continue
+		}
+
+		ipRanges := []string{}
+		for _, configured_route := range iface.IPRanges {
+			if configured_route != route.DestinationCIDR {
+				ipRanges = append(ipRanges, configured_route)
+			}
+		}
+
+		interfaceUpdateOptions := linodego.InstanceConfigInterfaceUpdateOptions{
+			IPRanges: ipRanges,
+		}
+		resp, err := r.client.UpdateInstanceConfigInterface(ctx, instance.ID, configs[0].ID, iface.ID, interfaceUpdateOptions)
+		if err != nil {
+			return err
+		}
+		klog.V(4).Infof("Deleted route for node %s. Current routes: %v", route.TargetNode, resp.IPRanges)
+		return nil
+	}
+	return fmt.Errorf("unable to remove route %s for node %s", route.DestinationCIDR, route.TargetNode)
+}
+
+// ListRoutes fetches routes configured on all instances which have VPC interfaces
+func (r *routes) ListRoutes(ctx context.Context, clusterName string) ([]*cloudprovider.Route, error) {
+	klog.V(4).Infof("Fetching routes configured on the cluster")
+	instances, err := r.instances.listAllInstances(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var routes []*cloudprovider.Route
+	for _, instance := range instances {
+		configs, err := r.getInstanceConfigs(ctx, instance.ID)
+		if err != nil {
+			klog.Errorf("Failed finding routes for instance id %d. Error: %v", instance.ID, err)
+			continue
+		}
+
+		for _, iface := range configs[0].Interfaces {
+			if iface.VPCID == nil || r.vpcid != *iface.VPCID || iface.IPv4.VPC == "" {
+				continue
+			}
+
+			for _, ipsubnet := range iface.IPRanges {
+				route := &cloudprovider.Route{
+					TargetNode:      types.NodeName(instance.Label),
+					DestinationCIDR: ipsubnet,
+				}
+				klog.V(4).Infof("Found route: node %s, route %s", instance.Label, route.DestinationCIDR)
+				routes = append(routes, route)
+			}
+		}
+	}
+	return routes, nil
+}

--- a/cloud/linode/route_controller.go
+++ b/cloud/linode/route_controller.go
@@ -92,6 +92,10 @@ func newRoutes(client client.Client) (cloudprovider.Routes, error) {
 	}
 	klog.V(3).Infof("TTL for routeCache set to %d", timeout)
 
+	if Options.EnableRouteController && VPCID == 0 {
+		return nil, fmt.Errorf("cannot enable route controller as vpc [%s] not found", Options.VPCName)
+	}
+
 	return &routes{
 		vpcid:     VPCID,
 		client:    client,

--- a/cloud/linode/route_controller_test.go
+++ b/cloud/linode/route_controller_test.go
@@ -1,0 +1,301 @@
+package linode
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/linode/linodego"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
+)
+
+func TestListRoutes(t *testing.T) {
+	Options.VPCName = "test"
+	Options.EnableRouteController = true
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := NewMockClient(ctrl)
+	VPCID = 1
+
+	nodeID := 123
+	name := "mock-instance"
+	publicIPv4 := net.ParseIP("45.76.101.25")
+	privateIPv4 := net.ParseIP("192.168.133.65")
+	linodeType := "g6-standard-1"
+	region := "us-east"
+
+	t.Run("should return empty if no instance exists in cluster", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), gomock.Any()).Times(1).Return([]linodego.Instance{}, nil)
+		client.EXPECT().GetVPC(gomock.Any(), gomock.Any()).Times(1).Return(&linodego.VPC{}, nil)
+		routes, err := routeController.ListRoutes(ctx, "abc")
+		assert.NoError(t, err)
+		assert.Empty(t, routes)
+	})
+
+	validInstance := linodego.Instance{ID: nodeID, Label: name, Type: linodeType, Region: region, IPv4: []*net.IP{&publicIPv4, &privateIPv4}}
+
+	t.Run("should return no routes if instance exists but is not connected to VPC", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetVPC(gomock.Any(), gomock.Any()).Times(1).Return(&linodego.VPC{}, nil)
+		routes, err := routeController.ListRoutes(ctx, "abc")
+		assert.NoError(t, err)
+		assert.Empty(t, routes)
+	})
+
+	instanceConfigWithVPCNoRoutes := linodego.InstanceConfig{
+		ID: 123456,
+		Interfaces: []linodego.InstanceConfigInterface{
+			{
+				VPCID: &VPCID,
+				IPv4:  linodego.VPCIPv4{VPC: "1.1.1.1"},
+			},
+		},
+	}
+	vpcWithInstance := linodego.VPC{
+		Subnets: []linodego.VPCSubnet{
+			{
+				Linodes: []linodego.VPCSubnetLinode{
+					{
+						ID:         nodeID,
+						Interfaces: []linodego.VPCSubnetLinodeInterface{},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("should return no routes if instance exists, connected to VPC but no ip_ranges configured", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetVPC(gomock.Any(), gomock.Any()).Times(2).Return(&vpcWithInstance, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(2).Return([]linodego.InstanceConfig{instanceConfigWithVPCNoRoutes}, nil)
+		routes, err := routeController.ListRoutes(ctx, "abc")
+		assert.NoError(t, err)
+		assert.Empty(t, routes)
+	})
+
+	instanceConfigWithVPCAndRoutes := linodego.InstanceConfig{
+		ID: 123456,
+		Interfaces: []linodego.InstanceConfigInterface{
+			{
+				VPCID:    &VPCID,
+				IPv4:     linodego.VPCIPv4{VPC: "1.1.1.1"},
+				IPRanges: []string{"10.10.10.0/24", "10.11.11.0/24"},
+			},
+		},
+	}
+
+	t.Run("should return routes if instance exists, connected to VPC and ip_ranges configured", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetVPC(gomock.Any(), gomock.Any()).Times(2).Return(&vpcWithInstance, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(2).Return([]linodego.InstanceConfig{instanceConfigWithVPCAndRoutes}, nil)
+		routes, err := routeController.ListRoutes(ctx, "abc")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, routes)
+		assert.Equal(t, "10.10.10.0/24", routes[0].DestinationCIDR)
+		assert.Equal(t, "10.11.11.0/24", routes[1].DestinationCIDR)
+	})
+
+	instanceConfigWithDifferentVPCAndRoutes := linodego.InstanceConfig{
+		ID: 123456,
+		Interfaces: []linodego.InstanceConfigInterface{
+			{
+				VPCID:    &nodeID,
+				IPv4:     linodego.VPCIPv4{VPC: "1.1.1.1"},
+				IPRanges: []string{"10.10.10.1"},
+			},
+		},
+	}
+
+	t.Run("should return no routes if instance exists, connected to VPC and ip_ranges configured but vpc id doesn't match", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetVPC(gomock.Any(), gomock.Any()).Times(2).Return(&vpcWithInstance, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(2).Return([]linodego.InstanceConfig{instanceConfigWithDifferentVPCAndRoutes}, nil)
+		routes, err := routeController.ListRoutes(ctx, "abc")
+		assert.NoError(t, err)
+		assert.Empty(t, routes)
+	})
+}
+
+func TestCreateRoute(t *testing.T) {
+	Options.VPCName = "test"
+	Options.EnableRouteController = true
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := NewMockClient(ctrl)
+	VPCID = 1
+
+	nodeID := 123
+	name := "mock-instance"
+	publicIPv4 := net.ParseIP("45.76.101.25")
+	privateIPv4 := net.ParseIP("192.168.133.65")
+	linodeType := "g6-standard-1"
+	region := "us-east"
+	validInstance := linodego.Instance{ID: nodeID, Label: name, Type: linodeType, Region: region, IPv4: []*net.IP{&publicIPv4, &privateIPv4}}
+
+	vpcWithInstance := linodego.VPC{
+		Subnets: []linodego.VPCSubnet{
+			{
+				Linodes: []linodego.VPCSubnetLinode{
+					{
+						ID:         nodeID,
+						Interfaces: []linodego.VPCSubnetLinodeInterface{},
+					},
+				},
+			},
+		},
+	}
+
+	instanceConfigWithVPCNoRoutes := linodego.InstanceConfig{
+		ID: 123456,
+		Interfaces: []linodego.InstanceConfigInterface{
+			{
+				VPCID: &VPCID,
+				IPv4:  linodego.VPCIPv4{VPC: "1.1.1.1"},
+			},
+		},
+	}
+	instanceConfigIntfWithVPCAndRoute := linodego.InstanceConfigInterface{
+		VPCID:    &VPCID,
+		IPv4:     linodego.VPCIPv4{VPC: "1.1.1.1"},
+		IPRanges: []string{"10.10.10.0/24"},
+	}
+	route := &cloudprovider.Route{
+		Name:            "route1",
+		TargetNode:      types.NodeName(name),
+		DestinationCIDR: "10.10.10.0/24",
+	}
+
+	t.Run("should return no error if instance exists, connected to VPC and route not present yet", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetVPC(gomock.Any(), gomock.Any()).Times(2).Return(&vpcWithInstance, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(2).Return([]linodego.InstanceConfig{instanceConfigWithVPCNoRoutes}, nil)
+		client.EXPECT().UpdateInstanceConfigInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&instanceConfigIntfWithVPCAndRoute, nil)
+		err = routeController.CreateRoute(ctx, "dummy", "dummy", route)
+		assert.NoError(t, err)
+	})
+
+	instanceConfigWithVPCAndRoutes := linodego.InstanceConfig{
+		ID:         123456,
+		Interfaces: []linodego.InstanceConfigInterface{instanceConfigIntfWithVPCAndRoute},
+	}
+
+	t.Run("should return no error if instance exists, connected to VPC and route already exists", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetVPC(gomock.Any(), gomock.Any()).Times(2).Return(&vpcWithInstance, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(2).Return([]linodego.InstanceConfig{instanceConfigWithVPCAndRoutes}, nil)
+		err = routeController.CreateRoute(ctx, "dummy", "dummy", route)
+		assert.NoError(t, err)
+	})
+
+	t.Run("should return error if instance doesn't exist", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return(nil, errors.New("Mock Error"))
+		err = routeController.CreateRoute(ctx, "dummy", "dummy", route)
+		assert.Error(t, err)
+	})
+}
+
+func TestDeleteRoute(t *testing.T) {
+	Options.VPCName = "test"
+	Options.EnableRouteController = true
+
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := NewMockClient(ctrl)
+	VPCID = 1
+
+	nodeID := 123
+	name := "mock-instance"
+	publicIPv4 := net.ParseIP("45.76.101.25")
+	privateIPv4 := net.ParseIP("192.168.133.65")
+	linodeType := "g6-standard-1"
+	region := "us-east"
+	validInstance := linodego.Instance{ID: nodeID, Label: name, Type: linodeType, Region: region, IPv4: []*net.IP{&publicIPv4, &privateIPv4}}
+	vpcWithInstance := linodego.VPC{
+		Subnets: []linodego.VPCSubnet{
+			{
+				Linodes: []linodego.VPCSubnetLinode{
+					{
+						ID:         nodeID,
+						Interfaces: []linodego.VPCSubnetLinodeInterface{},
+					},
+				},
+			},
+		},
+	}
+	route := &cloudprovider.Route{
+		Name:            "route1",
+		TargetNode:      types.NodeName(name),
+		DestinationCIDR: "10.10.10.0/24",
+	}
+	instanceConfigIntfWithVPCAndRoute := linodego.InstanceConfigInterface{
+		VPCID:    &VPCID,
+		IPv4:     linodego.VPCIPv4{VPC: "1.1.1.1"},
+		IPRanges: []string{"10.10.10.0/24"},
+	}
+	instanceConfigIntfWithVPCAndNoRoute := linodego.InstanceConfigInterface{
+		VPCID:    &VPCID,
+		IPv4:     linodego.VPCIPv4{VPC: "1.1.1.1"},
+		IPRanges: []string{},
+	}
+	instanceConfigWithVPCAndRoutes := linodego.InstanceConfig{
+		ID:         123456,
+		Interfaces: []linodego.InstanceConfigInterface{instanceConfigIntfWithVPCAndRoute},
+	}
+
+	t.Run("should return error if instance doesn't exist", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{}, errors.New("no instance"))
+		err = routeController.DeleteRoute(ctx, "dummy", route)
+		assert.Error(t, err)
+	})
+
+	t.Run("should return no error if instance exists, connected to VPC and route is deleted", func(t *testing.T) {
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetVPC(gomock.Any(), gomock.Any()).Times(2).Return(&vpcWithInstance, nil)
+		client.EXPECT().ListInstanceConfigs(gomock.Any(), 123, gomock.Any()).Times(2).Return([]linodego.InstanceConfig{instanceConfigWithVPCAndRoutes}, nil)
+		client.EXPECT().UpdateInstanceConfigInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&instanceConfigIntfWithVPCAndNoRoute, nil)
+		err = routeController.DeleteRoute(ctx, "dummy", route)
+		assert.NoError(t, err)
+	})
+}

--- a/cloud/linode/vpc.go
+++ b/cloud/linode/vpc.go
@@ -1,0 +1,31 @@
+package linode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/linode/linode-cloud-controller-manager/cloud/linode/client"
+	"github.com/linode/linodego"
+)
+
+type vpcLookupError struct {
+	value string
+}
+
+func (e vpcLookupError) Error() string {
+	return fmt.Sprintf("failed to find VPC: %q", e.value)
+}
+
+// getVPCID returns the VPC id using the VPC label
+func getVPCID(client client.Client, vpcName string) (int, error) {
+	vpcs, err := client.ListVPCs(context.TODO(), &linodego.ListOptions{})
+	if err != nil {
+		return 0, err
+	}
+	for _, vpc := range vpcs {
+		if vpc.Label == vpcName {
+			return vpc.ID, nil
+		}
+	}
+	return 0, vpcLookupError{vpcName}
+}

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -36,6 +36,15 @@ spec:
             {{- if .Values.linodegoDebug }}
             - --linodego-debug={{ .Values.linodegoDebug }}
             {{- end }}
+            {{- if .Values.routeController }}
+            - --enable-route-controller=true
+            - --vpc-name={{ .Values.routeController.vpcName }}
+            - --configure-cloud-routes={{ .Values.routeController.configureCloudRoutes }}
+            - --cluster-cidr={{ .Values.routeController.clusterCIDR }}
+            {{- if .Values.routeController.routeReconciliationPeriod }}
+            - --route-reconciliation-period={{ .Values.routeController.routeReconciliationPeriod }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - mountPath: /etc/kubernetes
               name: k8s

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -44,6 +44,12 @@ tolerations:
     operator: Exists
     effect: NoSchedule
 
+# This section adds ability to enable route-controller for ccm
+# routeController:
+#   vpcName: <name of VPC>
+#   clusterCIDR: 10.0.0.0/8
+#   configureCloudRoutes: true
+
 # This section adds the ability to pass environment variables to adjust CCM defaults
 # https://github.com/linode/linode-cloud-controller-manager/blob/master/cloud/linode/loadbalancers.go
 # LINODE_HOSTNAME_ONLY_INGRESS type bool is supported

--- a/main.go
+++ b/main.go
@@ -76,6 +76,8 @@ func main() {
 
 	// Add Linode-specific flags
 	command.Flags().BoolVar(&linode.Options.LinodeGoDebug, "linodego-debug", false, "enables debug output for the LinodeAPI wrapper")
+	command.Flags().BoolVar(&linode.Options.EnableRouteController, "enable-route-controller", false, "enables route_controller for ccm")
+	command.Flags().StringVar(&linode.Options.VPCName, "vpc-name", "", "vpc name whose routes will be managed by route-controller")
 
 	// Set static flags
 	command.Flags().VisitAll(func(fl *pflag.Flag) {


### PR DESCRIPTION
### General:
This PR reintroduces changes which were reverted in https://github.com/linode/linode-cloud-controller-manager/pull/196

Additional changes added to PR:
1. If we are running outside of VPC, we don't fetch InstanceConfigs
2. If we are running within VPC, we fetch InstanceConfigs for instances within the VPC

Note: In future, we would like to use /v4/vpcs/:id/ips to list all VPC ips so that we can get all instance's ips in just 2 calls than existing 1+len(nodes) calls.

Calls made every 20 secs in a 6 node cluster inside VPC (started CCM with linodego-debug flag set to true):
```
k logs --timestamps pod/ccm-linode-cbxwl -n kube-system -f | grep "/v4/"

2024-03-27T13:50:35.520144953Z GET  /v4/linode/instances  HTTP/1.1
2024-03-27T13:50:35.599625368Z GET  /v4/vpcs/41220  HTTP/1.1
2024-03-27T13:50:35.691136075Z GET  /v4/linode/instances/56323907/configs  HTTP/1.1
2024-03-27T13:50:35.696009496Z GET  /v4/linode/instances/56324011/configs  HTTP/1.1
2024-03-27T13:50:35.700781396Z GET  /v4/linode/instances/56323949/configs  HTTP/1.1
2024-03-27T13:50:35.701410791Z GET  /v4/linode/instances/56323970/configs  HTTP/1.1
2024-03-27T13:50:35.705268044Z GET  /v4/linode/instances/56323968/configs  HTTP/1.1
2024-03-27T13:50:35.727128327Z GET  /v4/linode/instances/56323974/configs  HTTP/1.1

2024-03-27T13:50:55.519257954Z GET  /v4/linode/instances  HTTP/1.1
2024-03-27T13:50:55.623009604Z GET  /v4/vpcs/41220  HTTP/1.1
2024-03-27T13:50:55.708633682Z GET  /v4/linode/instances/56324011/configs  HTTP/1.1
2024-03-27T13:50:55.721245148Z GET  /v4/linode/instances/56323970/configs  HTTP/1.1
2024-03-27T13:50:55.724830978Z GET  /v4/linode/instances/56323907/configs  HTTP/1.1
2024-03-27T13:50:55.737507344Z GET  /v4/linode/instances/56323974/configs  HTTP/1.1
2024-03-27T13:50:55.743463294Z GET  /v4/linode/instances/56323949/configs  HTTP/1.1
2024-03-27T13:50:55.751982925Z GET  /v4/linode/instances/56323968/configs  HTTP/1.1
```

When running outside of VPC, we don't have route-controller enabled and hence we don't get instance cache refreshes that often.
```
root@rah4-control-plane-4qjf5:~# k logs --timestamps pod/ccm-linode-v77kt -n kube-system -f | grep "/v4/"
2024-03-27T13:53:48.297701175Z GET  /v4/linode/instances  HTTP/1.1
2024-03-27T13:53:48.386284452Z GET  /v4/linode/instances  HTTP/1.1
2024-03-27T13:58:48.575691503Z GET  /v4/linode/instances  HTTP/1.1
2024-03-27T14:03:48.757060253Z GET  /v4/linode/instances  HTTP/1.1
2024-03-27T14:08:48.909781164Z GET  /v4/linode/instances  HTTP/1.1
2024-03-27T14:13:49.284562219Z GET  /v4/linode/instances  HTTP/1.1
```

Since route_controller gets triggered every 10 seconds and instance cache is valid for [15 seconds](https://github.com/linode/linode-cloud-controller-manager/blob/v0.4.2/cloud/linode/instances.go#L61-L66), each second iteration of route_controller (2*10) finds the instance cache expired and causes it to refresh. I would prefer to change route_controller's default triggering interval from 10 seconds to 60 seconds as its running too frequently and doing unnecessary work. Even if a node doesn't get its routes updated for 60 seconds when it joins the cluster, its fine and pods will come up fine, just that they won't be able to communicate with pods on other nodes for 60 seconds or so for the first time should be fine? I am open to discussions about it and come to some conclusion on what time we should set for route-reconciliation-period for route_controller.

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

