### PR TITLE
Lookup linode by IP instead if label or providerID do not match

### DIFF
--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -93,12 +93,8 @@ func (i *instances) linodeByIP(kNode *v1.Node) (*linodego.Instance, error) {
 		return nil, fmt.Errorf("no IP address found on node %s", kNode.Name)
 	}
 	for _, node := range i.nodeCache.nodes {
-		var nodeAddresses []string
 		for _, nodeIP := range node.IPv4 {
-			nodeAddresses = append(nodeAddresses, nodeIP.String())
-		}
-		for _, nodeIP := range nodeAddresses {
-			if slices.Contains(kNodeAddresses, nodeIP) {
+			if !nodeIP.IsPrivate() && slices.Contains(kNodeAddresses, nodeIP.String()) {
 				return node, nil
 			}
 		}

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 
-	"golang.org/x/exp/slices"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/linode/linodego"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 
 	"github.com/linode/linode-cloud-controller-manager/cloud/linode/client"

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -85,7 +85,7 @@ func (i *instances) linodeByIP(kNode *v1.Node) (*linodego.Instance, error) {
 	i.nodeCache.RLock()
 	defer i.nodeCache.RUnlock()
 	var kNodeAddresses []string
-	for _, address := range (kNode).Status.Addresses {
+	for _, address := range kNode.Status.Addresses {
 		if address.Type == "ExternalIP" || address.Type == "InternalIP" {
 			kNodeAddresses = append(kNodeAddresses, address.Address)
 		}

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -3,12 +3,13 @@ package linode
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"os"
-	"slices"
 	"strconv"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/linode/linodego"
 	v1 "k8s.io/api/core/v1"

--- a/cloud/linode/instances_test.go
+++ b/cloud/linode/instances_test.go
@@ -42,17 +42,6 @@ func TestInstanceExists(t *testing.T) {
 		assert.False(t, exists)
 	})
 
-	t.Run("should return false if linode does not exist (by name)", func(t *testing.T) {
-		instances := newInstances(client)
-		name := "some-name"
-		node := nodeWithName(name)
-		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{}, nil)
-
-		exists, err := instances.InstanceExists(ctx, node)
-		assert.NoError(t, err)
-		assert.False(t, exists)
-	})
-
 	t.Run("should return true if linode exists (by provider)", func(t *testing.T) {
 		instances := newInstances(client)
 		node := nodeWithProviderID(providerIDPrefix + "123")
@@ -92,15 +81,18 @@ func TestMetadataRetrieval(t *testing.T) {
 
 	client := NewMockClient(ctrl)
 
-	t.Run("errors when linode does not exist (by name)", func(t *testing.T) {
+	t.Run("uses name over IP for finding linode", func(t *testing.T) {
 		instances := newInstances(client)
-		name := "does-not-exist"
+		publicIP := net.ParseIP("172.234.31.123")
+		privateIP := net.ParseIP("192.168.159.135")
+		expectedInstance := linodego.Instance{Label: "expected-instance", ID: 12345, IPv4: []*net.IP{&publicIP, &privateIP}}
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{{Label: "wrong-instance", ID: 3456, IPv4: []*net.IP{&publicIP, &privateIP}}, expectedInstance}, nil)
+		name := "expected-instance"
 		node := nodeWithName(name)
-		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{}, nil)
 
 		meta, err := instances.InstanceMetadata(ctx, node)
-		assert.ErrorIs(t, err, cloudprovider.InstanceNotFound)
-		assert.Nil(t, meta)
+		assert.Nil(t, err)
+		assert.Equal(t, providerIDPrefix+strconv.Itoa(expectedInstance.ID), meta.ProviderID)
 	})
 
 	t.Run("fails when linode does not exist (by provider)", func(t *testing.T) {
@@ -223,6 +215,65 @@ func TestMetadataRetrieval(t *testing.T) {
 				assert.Equal(t, meta.NodeAddresses, addresses)
 			}
 		})
+
+		getByIPTests := []struct {
+			name          string
+			nodeAddresses []v1.NodeAddress
+			expectedErr   error
+		}{
+			{name: "gets linode by External IP", nodeAddresses: []v1.NodeAddress{{
+				Type:    "ExternalIP",
+				Address: "172.234.31.123",
+			}, {
+				Type:    "InternalIP",
+				Address: "192.168.159.135",
+			}}},
+			{
+				name: "returns error on node with only internal IP", nodeAddresses: []v1.NodeAddress{{
+					Type:    "ExternalIP",
+					Address: "123.2.1.23",
+				}, {
+					Type:    "InternalIP",
+					Address: "192.168.159.135",
+				}},
+				expectedErr: cloudprovider.InstanceNotFound,
+			},
+			{
+				name: "returns error on no matching nodes by IP", nodeAddresses: []v1.NodeAddress{{
+					Type:    "ExternalIP",
+					Address: "123.2.1.23",
+				}, {
+					Type:    "InternalIP",
+					Address: "192.168.10.10",
+				}},
+				expectedErr: cloudprovider.InstanceNotFound,
+			},
+			{
+				name: "returns error on no node IPs", nodeAddresses: []v1.NodeAddress{},
+				expectedErr: fmt.Errorf("no IP address found on node test-node-1"),
+			},
+		}
+
+		for _, test := range getByIPTests {
+			t.Run(fmt.Sprintf("gets lindoe by IP - %s", test.name), func(t *testing.T) {
+				instances := newInstances(client)
+
+				publicIP := net.ParseIP("172.234.31.123")
+				privateIP := net.ParseIP("192.168.159.135")
+				wrongIP := net.ParseIP("1.2.3.4")
+				expectedInstance := linodego.Instance{Label: "expected-instance", ID: 12345, IPv4: []*net.IP{&publicIP, &privateIP}}
+				client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{{ID: 3456, IPv4: []*net.IP{&wrongIP}}, expectedInstance}, nil)
+				node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-1"}, Status: v1.NodeStatus{Addresses: test.nodeAddresses}}
+				meta, err := instances.InstanceMetadata(ctx, &node)
+				if test.expectedErr != nil {
+					assert.Nil(t, meta)
+					assert.Equal(t, err, test.expectedErr)
+				} else {
+					assert.Nil(t, err)
+					assert.Equal(t, providerIDPrefix+strconv.Itoa(expectedInstance.ID), meta.ProviderID)
+				}
+			})
+		}
 	}
 }
 
@@ -242,89 +293,6 @@ func TestMalformedProviders(t *testing.T) {
 
 		assert.ErrorIs(t, err, invalidProviderIDError{providerID})
 		assert.Nil(t, meta)
-	})
-}
-
-func TestProviderByIP(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	client := NewMockClient(ctrl)
-
-	t.Run("gets linode by external IP", func(t *testing.T) {
-		instances := newInstances(client)
-
-		publicIP := net.ParseIP("172.234.31.123")
-		privateIP := net.ParseIP("192.168.159.135")
-		wrongIP := net.ParseIP("1.2.3.4")
-		expectedInstance := linodego.Instance{ID: 12345, IPv4: []*net.IP{&publicIP, &privateIP}}
-		instances.nodeCache.nodes = map[int]*linodego.Instance{0: {ID: 54363, IPv4: []*net.IP{&wrongIP}}, 1: &expectedInstance}
-		node := v1.Node{Status: v1.NodeStatus{Addresses: []v1.NodeAddress{
-			{
-				Type:    "Hostname",
-				Address: "node1.linodelke.com",
-			}, {
-				Type:    "ExternalIP",
-				Address: "172.234.31.123",
-			},
-		}}}
-		k8sNode, err := instances.linodeByIP(&node)
-		assert.Nil(t, err)
-		assert.Equal(t, expectedInstance.ID, k8sNode.ID)
-	})
-
-	t.Run("gets linode by internal IP", func(t *testing.T) {
-		instances := newInstances(client)
-
-		publicIP := net.ParseIP("172.234.31.123")
-		privateIP := net.ParseIP("192.168.159.135")
-		wrongIP := net.ParseIP("1.2.3.4")
-		expectedInstance := linodego.Instance{ID: 12345, IPv4: []*net.IP{&publicIP, &privateIP}}
-		instances.nodeCache.nodes = map[int]*linodego.Instance{0: {ID: 54363, IPv4: []*net.IP{&wrongIP}}, 1: &expectedInstance}
-		node := v1.Node{Status: v1.NodeStatus{Addresses: []v1.NodeAddress{{
-			Type:    "ExternalIP",
-			Address: "324.2.1.23",
-		}, {
-			Type:    "InternalIP",
-			Address: "192.168.159.135",
-		}}}}
-		k8sNode, err := instances.linodeByIP(&node)
-		assert.Nil(t, err)
-		assert.Equal(t, expectedInstance.ID, k8sNode.ID)
-	})
-
-	t.Run("returns error on no matching nodes by IP", func(t *testing.T) {
-		instances := newInstances(client)
-
-		publicIP := net.ParseIP("172.234.31.200")
-		privateIP := net.ParseIP("192.168.159.200")
-		wrongIP := net.ParseIP("1.2.3.4")
-		expectedInstance := linodego.Instance{ID: 12345, IPv4: []*net.IP{&publicIP, &privateIP}}
-		instances.nodeCache.nodes = map[int]*linodego.Instance{0: {ID: 54363, IPv4: []*net.IP{&wrongIP}}, 1: &expectedInstance}
-		node := v1.Node{Status: v1.NodeStatus{Addresses: []v1.NodeAddress{{
-			Type:    "ExternalIP",
-			Address: "324.2.1.23",
-		}, {
-			Type:    "InternalIP",
-			Address: "192.168.159.135",
-		}}}}
-		k8sNode, err := instances.linodeByIP(&node)
-		assert.Nil(t, k8sNode)
-		assert.ErrorContains(t, err, "instance not found")
-	})
-
-	t.Run("returns error on no node IPs", func(t *testing.T) {
-		instances := newInstances(client)
-
-		publicIP := net.ParseIP("172.234.31.200")
-		privateIP := net.ParseIP("192.168.159.200")
-		wrongIP := net.ParseIP("1.2.3.4")
-		expectedInstance := linodego.Instance{ID: 12345, IPv4: []*net.IP{&publicIP, &privateIP}}
-		instances.nodeCache.nodes = map[int]*linodego.Instance{0: {ID: 54363, IPv4: []*net.IP{&wrongIP}}, 1: &expectedInstance}
-		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-1"}, Status: v1.NodeStatus{Addresses: []v1.NodeAddress{}}}
-		k8sNode, err := instances.linodeByIP(&node)
-		assert.Nil(t, k8sNode)
-		assert.ErrorContains(t, err, "no IP address found on node test-node-1")
 	})
 }
 

--- a/cloud/linode/instances_test.go
+++ b/cloud/linode/instances_test.go
@@ -254,14 +254,14 @@ func TestMetadataRetrieval(t *testing.T) {
 			},
 		}
 
+		publicIP := net.ParseIP("172.234.31.123")
+		privateIP := net.ParseIP("192.168.159.135")
+		wrongIP := net.ParseIP("1.2.3.4")
+		expectedInstance := linodego.Instance{Label: "expected-instance", ID: 12345, IPv4: []*net.IP{&publicIP, &privateIP}}
+
 		for _, test := range getByIPTests {
 			t.Run(fmt.Sprintf("gets lindoe by IP - %s", test.name), func(t *testing.T) {
 				instances := newInstances(client)
-
-				publicIP := net.ParseIP("172.234.31.123")
-				privateIP := net.ParseIP("192.168.159.135")
-				wrongIP := net.ParseIP("1.2.3.4")
-				expectedInstance := linodego.Instance{Label: "expected-instance", ID: 12345, IPv4: []*net.IP{&publicIP, &privateIP}}
 				client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{{ID: 3456, IPv4: []*net.IP{&wrongIP}}, expectedInstance}, nil)
 				node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test-node-1"}, Status: v1.NodeStatus{Addresses: test.nodeAddresses}}
 				meta, err := instances.InstanceMetadata(ctx, &node)

--- a/cloud/linode/node_controller.go
+++ b/cloud/linode/node_controller.go
@@ -138,25 +138,28 @@ func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
 		return err
 	}
 
-	if uuid == linode.HostUUID {
+	if uuid == linode.HostUUID && node.Spec.ProviderID != "" {
 		s.SetLastMetadataUpdate(node.Name)
 		return nil
 	}
 
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		// Get a fresh copy of the node so the resource version is up to date
+		// Get a fresh copy of the node so the resource version is up-to-date
 		n, err := s.kubeclient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
-		// It may be that the UUID has been set
-		if n.Labels[annotations.AnnLinodeHostUUID] == linode.HostUUID {
-			return nil
+		// Try to update the node UUID if it has not been set
+		if n.Labels[annotations.AnnLinodeHostUUID] != linode.HostUUID {
+			n.Labels[annotations.AnnLinodeHostUUID] = linode.HostUUID
 		}
 
-		// Try to update the node
-		n.Labels[annotations.AnnLinodeHostUUID] = linode.HostUUID
+		// Try to update the node ProviderID if it has not been set
+		if n.Spec.ProviderID == "" {
+			n.Spec.ProviderID = providerIDPrefix + strconv.Itoa(linode.ID)
+		}
+
 		_, err = s.kubeclient.CoreV1().Nodes().Update(ctx, n, metav1.UpdateOptions{})
 		return err
 	}); err != nil {


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

This change adds a `lookupByIP` function if a linode cannot be found by label or ID. This means rather that as long as the node and linode share an IP address it will be able to lookup the linode. additionally, we now set the ProviderID based on this lookup if it is not already set so future lookups only need to be made against the ID.

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

