### PR TITLE
Set toolchain go1.22.2 go.mod

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -2,6 +2,8 @@ module e2e_test
 
 go 1.22
 
+toolchain go1.22.2
+
 require (
 	github.com/appscode/go v0.0.0-20200323182826-54e98e09185a
 	github.com/linode/linodego v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/linode/linode-cloud-controller-manager
 
 go 1.22
 
+toolchain go1.22.2
+
 require (
 	github.com/appscode/go v0.0.0-20200323182826-54e98e09185a
 	github.com/getsentry/sentry-go v0.4.0


### PR DESCRIPTION
My go can't download toolchain:

```bash
go env
go: downloading go1.22 (linux/amd64)
go: download go1.22 for linux/amd64: toolchain not available
```
Here is the answer why: https://github.com/golang/go/issues/62278#issuecomment-1693538776

Fixes: https://github.com/linode/linode-cloud-controller-manager/issues/202

### General:

* [X] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [X] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [X] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [X] Are you addressing a single feature in this PR? 
1. [X] Are your commits atomic, addressing one change per commit?
1. [X] Are you following the conventions of the language? 
1. [X] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [X] Have you explained your rationale for why this feature is needed? 
1. [X] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

