### PR TITLE
ignore LoadBalancer Service if loadBalancerClass is set to cilium

### DIFF
--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -185,6 +185,11 @@ func (l *loadbalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 	sentry.SetTag(ctx, "cluster_name", clusterName)
 	sentry.SetTag(ctx, "service", service.Name)
 
+	if service.Spec.LoadBalancerClass != nil && *service.Spec.LoadBalancerClass == "io.cilium/bgp-control-plane" {
+		klog.Infof("Skipping NodeBalancer creation for Cilium LoadBalancerClass")
+		return lbStatus, err
+	}
+
 	var nb *linodego.NodeBalancer
 	serviceNn := getServiceNn(service)
 

--- a/cloud/linode/service_controller.go
+++ b/cloud/linode/service_controller.go
@@ -40,7 +40,8 @@ func (s *serviceController) Run(stopCh <-chan struct{}) {
 				return
 			}
 
-			if service.Spec.Type != "LoadBalancer" {
+			if service.Spec.Type != "LoadBalancer" ||
+				(service.Spec.LoadBalancerClass != nil && *service.Spec.LoadBalancerClass == "io.cilium/bgp-control-plane") {
 				return
 			}
 


### PR DESCRIPTION
This PR is to support cases where the linode-CCM is installed but instead of backing a LoadBalancer Service via NodeBalancers, the user wants to leverage [Cilium's BGP load balancing](https://docs.cilium.io/en/stable/network/bgp-control-plane/#service-announcements) via specifying so on the [Service's `loadBalancerClass`](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class). 
If the `loadBalancerClass` is not specified, the Service will by default be backed by a NodeBalancer as usual.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

