### PR TITLE
update client to work for v4beta API

### DIFF
--- a/cloud/linode/client/client.go
+++ b/cloud/linode/client/client.go
@@ -4,9 +4,6 @@ package client
 
 import (
 	"context"
-	"net/url"
-	"regexp"
-	"strings"
 
 	"github.com/linode/linodego"
 )
@@ -48,30 +45,12 @@ var _ Client = (*linodego.Client)(nil)
 // New creates a new linode client with a given token, userAgent, and API URL
 func New(token, userAgent, apiURL string) (*linodego.Client, error) {
 	linodeClient := linodego.NewClient(nil)
-	linodeClient.SetUserAgent(userAgent)
-	linodeClient.SetToken(token)
-
-	// Validate apiURL
-	parsedURL, err := url.Parse(apiURL)
+	client, err := linodeClient.UseURL(apiURL)
 	if err != nil {
 		return nil, err
 	}
+	client.SetUserAgent(userAgent)
+	client.SetToken(token)
 
-	validatedURL := &url.URL{
-		Host:   parsedURL.Host,
-		Scheme: parsedURL.Scheme,
-	}
-
-	linodeClient.SetBaseURL(validatedURL.String())
-
-	version := ""
-	matches := regexp.MustCompile(`/v\d+`).FindAllString(parsedURL.Path, -1)
-
-	if len(matches) > 0 {
-		version = strings.Trim(matches[len(matches)-1], "/")
-	}
-
-	linodeClient.SetAPIVersion(version)
-
-	return &linodeClient, nil
+	return client, nil
 }


### PR DESCRIPTION
Currently the regex for parsing the `LINODE_URL` env var does not work for the v4beta version of the Linode API. This makes it so v4beta can be used if needed (see https://github.com/linode/linodego/blob/main/client.go#L149).

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

