### PR TITLE
[bugfix] - handle LoadBalancer deletion if service type changes to no longer be a LoadBalancer

### DIFF
--- a/cloud/linode/service_controller.go
+++ b/cloud/linode/service_controller.go
@@ -47,6 +47,21 @@ func (s *serviceController) Run(stopCh <-chan struct{}) {
 			klog.Infof("ServiceController will handle service (%s) deletion", getServiceNn(service))
 			s.queue.Add(service)
 		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			newSvc, ok := newObj.(*v1.Service)
+			if !ok {
+				return
+			}
+			oldSvc, ok := oldObj.(*v1.Service)
+			if !ok {
+				return
+			}
+
+			if newSvc.Spec.Type != "LoadBalancer" && oldSvc.Spec.Type == "LoadBalancer" {
+				klog.Infof("ServiceController will handle service (%s) LoadBalancer deletion", getServiceNn(oldSvc))
+				s.queue.Add(oldSvc)
+			}
+		},
 	}); err != nil {
 		klog.Errorf("ServiceController didn't successfully register it's Informer %s", err)
 	}


### PR DESCRIPTION
There's currently a bug that leaves an orphaned NodeBalancer if a Service's type changes to no longer be `LoadBalancer`. If the type is changed back, a new NodeBalancer is created. 
This PR detects a change in Service type and deletes the NodeBalancer if necessary.

e.g. when doing a `kubectl edit` on a Service to instead be a NodePort type:
```
I0521 14:43:02.423709       1 service_controller.go:61] ServiceController will handle service (test-ns2/test-svc) LoadBalancer deletion
I0521 14:43:02.423736       1 service_controller.go:111] ServiceController handling service (test-ns2/test-svc) deletion
I0521 14:43:02.424889       1 controller.go:969] Removing finalizer from service test-ns2/test-svc
I0521 14:43:02.425893       1 event.go:376] "Event occurred" object="test-ns2/test-svc" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="Type" message="LoadBalancer -> NodePort"
I0521 14:43:02.431744       1 event.go:376] "Event occurred" object="test-ns2/test-svc" fieldPath="" kind="Service" apiVersion="v1" type="Normal" reason="DeletedLoadBalancer" message="Deleted load balancer"
I0521 14:43:02.527551       1 loadbalancers.go:498] found NodeBalancer (675801) for service (test-ns2/test-svc) via IPv4 (172.232.16.7)
I0521 14:43:02.668512       1 loadbalancers.go:471] successfully deleted NodeBalancer (675801) for service (test-ns2/test-svc)
```

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

