### PR TITLE
fix: remove firewall device by device ID not entity ID

### DIFF
--- a/cloud/linode/firewall/firewalls.go
+++ b/cloud/linode/firewall/firewalls.go
@@ -260,11 +260,17 @@ func (l *LinodeClient) UpdateNodeBalancerFirewall(
 		klog.Errorf("Found more than one firewall attached to nodebalancer: %d, firewall IDs: %v", nb.ID, firewalls)
 		return ErrTooManyNBFirewalls
 	}
-
-	err = l.Client.DeleteFirewallDevice(ctx, firewalls[0].ID, nb.ID)
+	deviceID, deviceExists, err := l.getNodeBalancerDeviceID(ctx, firewalls[0].ID, nb.ID)
 	if err != nil {
 		return err
 	}
+	if deviceExists {
+		err = l.Client.DeleteFirewallDevice(ctx, firewalls[0].ID, deviceID)
+		if err != nil {
+			return err
+		}
+	}
+
 	// once we delete the device, we should see if there's anything attached to that firewall
 	devices, err := l.Client.ListFirewallDevices(ctx, firewalls[0].ID, &linodego.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

Currently when you remove a `service.beta.kubernetes.io/linode-loadbalancer-firewall-acl` annotation from a service, the ccm attempts to use the NodeBalancerID when attempting to delete the device which results in a 404 from the Linode API which expects the FirewallDeviceID in the request instead. This PR re-uses the getNodeBalancerDeviceID function to get the DeviceID and use that in the delete request instead