### PR TITLE
fix: use tag ref for helm-release so the release workflow can start it

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -47,7 +47,7 @@ jobs:
       #  run: ct install --chart-dirs helm-chart --namespace kube-system --helm-extra-set-args "--set=apiToken=test --set=region=us-east"  --target-branch ${{ github.event.repository.default_branch }}
 
   helm-release:
-    if: github.ref == 'refs/heads/main'
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     needs: helm-test
     permissions:
       contents: write  # for helm/chart-releaser-action to push chart release and create a release


### PR DESCRIPTION
### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

https://github.com/linode/linode-cloud-controller-manager/pull/179 should have restricted helm-releases to be kicked off via the release workflow, but when the happens github.ref gets set to the git ref of the newly created tag and is no longer main. This resulted in the job getting skipped and only the test running on releases. 

This PR switches the conditional to look for a github.ref that starts with `/ref/tags/` instead