### PR TITLE
include ipv6 address for node external IPs

### DIFF
--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -36,8 +36,8 @@ type nodeCache struct {
 	ttl        time.Duration
 }
 
-// getInstanceIPv4Addresses returns all ipv4 addresses configured on a linode.
-func (nc *nodeCache) getInstanceIPv4Addresses(instance linodego.Instance, vpcips []string) []nodeIP {
+// getInstanceAddresses returns all addresses configured on a linode.
+func (nc *nodeCache) getInstanceAddresses(instance linodego.Instance, vpcips []string) []nodeIP {
 	ips := []nodeIP{}
 
 	// If vpc ips are present, list them first
@@ -52,6 +52,10 @@ func (nc *nodeCache) getInstanceIPv4Addresses(instance linodego.Instance, vpcips
 			ipType = v1.NodeInternalIP
 		}
 		ips = append(ips, nodeIP{ip: ip.String(), ipType: ipType})
+	}
+
+	if instance.IPv6 != "" {
+		ips = append(ips, nodeIP{ip: instance.IPv6, ipType: v1.NodeExternalIP})
 	}
 
 	return ips
@@ -97,7 +101,7 @@ func (nc *nodeCache) refreshInstances(ctx context.Context, client client.Client)
 		}
 		node := linodeInstance{
 			instance: &instances[i],
-			ips:      nc.getInstanceIPv4Addresses(instance, vpcNodes[instance.ID]),
+			ips:      nc.getInstanceAddresses(instance, vpcNodes[instance.ID]),
 		}
 		newNodes[instance.ID] = node
 	}
@@ -141,7 +145,7 @@ func (i *instances) linodeByIP(kNode *v1.Node) (*linodego.Instance, error) {
 	defer i.nodeCache.RUnlock()
 	var kNodeAddresses []string
 	for _, address := range kNode.Status.Addresses {
-		if address.Type == "ExternalIP" || address.Type == "InternalIP" {
+		if address.Type == v1.NodeExternalIP || address.Type == v1.NodeInternalIP {
 			kNodeAddresses = append(kNodeAddresses, address.Address)
 		}
 	}
@@ -262,7 +266,7 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 		return nil, err
 	}
 
-	ips, err := i.getLinodeIPv4Addresses(ctx, node)
+	ips, err := i.getLinodeAddresses(ctx, node)
 	if err != nil {
 		sentry.CaptureError(ctx, err)
 		return nil, err
@@ -291,7 +295,7 @@ func (i *instances) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloud
 	return meta, nil
 }
 
-func (i *instances) getLinodeIPv4Addresses(ctx context.Context, node *v1.Node) ([]nodeIP, error) {
+func (i *instances) getLinodeAddresses(ctx context.Context, node *v1.Node) ([]nodeIP, error) {
 	ctx = sentry.SetHubOnContext(ctx)
 	instance, err := i.lookupLinode(ctx, node)
 	if err != nil {

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,7 +56,7 @@ func (nc *nodeCache) getInstanceAddresses(instance linodego.Instance, vpcips []s
 	}
 
 	if instance.IPv6 != "" {
-		ips = append(ips, nodeIP{ip: instance.IPv6, ipType: v1.NodeExternalIP})
+		ips = append(ips, nodeIP{ip: strings.TrimSuffix(instance.IPv6, "/128"), ipType: v1.NodeExternalIP})
 	}
 
 	return ips


### PR DESCRIPTION
This updates Nodes to also have their ipv6 address set for their external IPs to support dual-stack / ipv6-enabled clusters.
 
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

