### PR TITLE
add context timeouts when making calls to linodeapi

### DIFF
--- a/cloud/linode/common.go
+++ b/cloud/linode/common.go
@@ -4,11 +4,16 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/linode/linodego"
 )
 
-const providerIDPrefix = "linode://"
+const (
+	providerIDPrefix = "linode://"
+	// context timeout for API requests
+	requestTimeout = 120 * time.Second
+)
 
 type invalidProviderIDError struct {
 	value string

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -59,13 +59,16 @@ func (nc *nodeCache) getInstanceIPv4Addresses(instance linodego.Instance, vpcips
 
 // refreshInstances conditionally loads all instances from the Linode API and caches them.
 // It does not refresh if the last update happened less than `nodeCache.ttl` ago.
-func (nc *nodeCache) refreshInstances(ctx context.Context, client client.Client) error {
+func (nc *nodeCache) refreshInstances(_ context.Context, client client.Client) error {
 	nc.Lock()
 	defer nc.Unlock()
 
 	if time.Since(nc.lastUpdate) < nc.ttl {
 		return nil
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
 
 	instances, err := client.ListInstances(ctx, nil)
 	if err != nil {

--- a/cloud/linode/vpc.go
+++ b/cloud/linode/vpc.go
@@ -18,7 +18,9 @@ func (e vpcLookupError) Error() string {
 
 // getVPCID returns the VPC id using the VPC label
 func getVPCID(client client.Client, vpcName string) (int, error) {
-	vpcs, err := client.ListVPCs(context.TODO(), &linodego.ListOptions{})
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	vpcs, err := client.ListVPCs(ctx, &linodego.ListOptions{})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### Why this PR is needed
We see cloud-controller-manager stuck for 10-15 mins when doing vpcless installs with firewalling enabled using cluster-api-provider-linode. Upon further troubleshooting, we see some calls getting stuck for more than 10 mins:
```
2024/06/17 13:23:11.262239 DEBUG RESTY
==============================================================================
~~~ REQUEST ~~~
GET  /v4/linode/instances  HTTP/1.1
HOST   : api.linode.com
HEADERS:
	Accept: application/json
	Authorization: Bearer XXXX
	Content-Type: application/json
	User-Agent: linode-cloud-controller-manager linodego/v1.33.0 https://github.com/linode/linodego
BODY   :
***** NO CONTENT *****
------------------------------------------------------------------------------
~~~ RESPONSE ~~~
STATUS       : 200 OK
PROTO        : HTTP/1.1
RECEIVED AT  : 2024-06-17T13:23:11.262101656Z
TIME DURATION: 15m47.632783808s
HEADERS      :
	Access-Control-Allow-Credentials: true
```
At some places, we have created context without any timeout. We also found that upstream cloud-provider golang code also creates context without timeout and such requests can get stuck sometimes.
https://github.com/kubernetes/cloud-provider/blob/v0.29.3/controllers/node/node_controller.go#L255
https://github.com/kubernetes/cloud-provider/blob/v0.29.3/controllers/service/controller.go#L845

**NOTE**: Files containing code for firewall and loadbalancers/cilium_loadbalancers implementation are not changed in this PR to keep the changes minimum. We haven't seen issues with those calls getting stuck. If we think we should also update those calls, I can add those changes as well.

#### Steps to reproduce the issue using CAPL:
1. Provision new CAPL cluster
```
CONTROL_PLANE_MACHINE_COUNT=3 WORKER_MACHINE_COUNT=3 FW_AUDIT_ONLY=false clusterctl generate cluster vpcless --infrastructure local-linode:v0.0.0 --flavor kubeadm-vpcless | k apply -f -
```
2. Check time taken by nodes to come up and join the cluster. Third control plane node would have taken more than 12-15mins after the second control plane node joined the cluster.

#### How to test the fix
Provision CAPL cluster for vpcless flavor with linode-ccm image set to image built from this patch. I have a custom image with this patch at `docker.io/rahulait/ccm:context`. Once provisioned, check and see that nodes have joined the cluster without much gaps between their provisioning.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

