### PR TITLE
add timeout for linodego http client

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,15 @@ sessionAffinityConfig:
     timeoutSeconds: 100
 ```
 
+## Additional environment variables
+To tweak CCM based on needs, one can overwrite the default values set for caches and requests by setting appropriate environment variables when applying the manifest or helm chart.
+
+Environment Variable | Default | Description
+---|---|---
+`LINODE_INSTANCE_CACHE_TTL` | `15` | Default timeout of instance cache in seconds
+`LINODE_ROUTES_CACHE_TTL_SECONDS` | `60` | Default timeout of route cache in seconds
+`LINODE_REQUEST_TIMEOUT_SECONDS` | `120` | Default timeout in seconds for http requests to linode API
+
 ## Generating a Manifest for Deployment
 Use the script located at `./deploy/generate-manifest.sh` to generate a self-contained deployment manifest for the Linode CCM. Two arguments are required.
 
@@ -320,7 +329,7 @@ helm repo update ccm-linode
 ### To deploy ccm-linode. Run the following command:
 
 ```sh
-export VERSION=v0.3.22
+export VERSION=v0.4.8
 export LINODE_API_TOKEN=<linodeapitoken>
 export REGION=<linoderegion>
 helm install ccm-linode --set apiToken=$LINODE_API_TOKEN,region=$REGION ccm-linode/ccm-linode
@@ -335,7 +344,7 @@ _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command doc
 
 ### To upgrade when new changes are made to the helm chart. Run the following command:
 ```sh
-export VERSION=v0.3.22
+export VERSION=v0.4.8
 export LINODE_API_TOKEN=<linodeapitoken>
 export REGION=<linoderegion>
 

--- a/cloud/linode/client/client.go
+++ b/cloud/linode/client/client.go
@@ -4,7 +4,9 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/linode/linodego"
@@ -56,8 +58,11 @@ type Client interface {
 // linodego.Client implements Client
 var _ Client = (*linodego.Client)(nil)
 
-// New creates a new linode client with a given token, userAgent, and API URL
-func New(token, userAgent, apiURL string, timeout time.Duration) (*linodego.Client, error) {
+// New creates a new linode client with a given token and default timeout
+func New(token string, timeout time.Duration) (*linodego.Client, error) {
+	userAgent := fmt.Sprintf("linode-cloud-controller-manager %s", linodego.DefaultUserAgent)
+	apiURL := os.Getenv("LINODE_URL")
+
 	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	oauth2Client := &http.Client{
 		Transport: &oauth2.Transport{
@@ -72,6 +77,6 @@ func New(token, userAgent, apiURL string, timeout time.Duration) (*linodego.Clie
 	}
 	client.SetUserAgent(userAgent)
 
-	klog.V(3).Infof("Linode client created with default timeout of %v seconds", timeout)
+	klog.V(3).Infof("Linode client created with default timeout of %v", timeout)
 	return client, nil
 }

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"sync"
+	"time"
 
 	"github.com/linode/linodego"
 	"github.com/spf13/pflag"
@@ -98,7 +100,15 @@ func newCloud() (cloudprovider.Interface, error) {
 	url := os.Getenv(urlEnv)
 	ua := fmt.Sprintf("linode-cloud-controller-manager %s", linodego.DefaultUserAgent)
 
-	linodeClient, err := client.New(apiToken, ua, url)
+	// set timeout used by linodeclient for API calls
+	timeout := client.DefaultClientTimeout
+	if raw, ok := os.LookupEnv("LINODE_REQUEST_TIMEOUT_SECONDS"); ok {
+		if t, _ := strconv.Atoi(raw); t > 0 {
+			timeout = time.Duration(t) * time.Second
+		}
+	}
+
+	linodeClient, err := client.New(apiToken, ua, url, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("client was not created succesfully: %w", err)
 	}

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/linode/linodego"
 	"github.com/spf13/pflag"
 	"golang.org/x/exp/slices"
 	"k8s.io/client-go/informers"
@@ -22,7 +21,6 @@ const (
 	ProviderName       = "linode"
 	accessTokenEnv     = "LINODE_API_TOKEN"
 	regionEnv          = "LINODE_REGION"
-	urlEnv             = "LINODE_URL"
 	ciliumLBType       = "cilium-bgp"
 	nodeBalancerLBType = "nodebalancer"
 )
@@ -97,18 +95,15 @@ func newCloud() (cloudprovider.Interface, error) {
 		return nil, fmt.Errorf("%s must be set in the environment (use a k8s secret)", regionEnv)
 	}
 
-	url := os.Getenv(urlEnv)
-	ua := fmt.Sprintf("linode-cloud-controller-manager %s", linodego.DefaultUserAgent)
-
 	// set timeout used by linodeclient for API calls
 	timeout := client.DefaultClientTimeout
 	if raw, ok := os.LookupEnv("LINODE_REQUEST_TIMEOUT_SECONDS"); ok {
-		if t, _ := strconv.Atoi(raw); t > 0 {
+		if t, err := strconv.Atoi(raw); err == nil && t > 0 {
 			timeout = time.Duration(t) * time.Second
 		}
 	}
 
-	linodeClient, err := client.New(apiToken, ua, url, timeout)
+	linodeClient, err := client.New(apiToken, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("client was not created succesfully: %w", err)
 	}


### PR DESCRIPTION
### Why this PR is needed
We see cloud-controller-manager stuck for 10-15 mins when doing vpcless installs with firewalling enabled using cluster-api-provider-linode. Upon further troubleshooting, we see some calls getting stuck for more than 10 mins:
```
2024/06/17 13:23:11.262239 DEBUG RESTY
==============================================================================
~~~ REQUEST ~~~
GET  /v4/linode/instances  HTTP/1.1
HOST   : api.linode.com
HEADERS:
	Accept: application/json
	Authorization: Bearer XXXX
	Content-Type: application/json
	User-Agent: linode-cloud-controller-manager linodego/v1.33.0 https://github.com/linode/linodego
BODY   :
***** NO CONTENT *****
------------------------------------------------------------------------------
~~~ RESPONSE ~~~
STATUS       : 200 OK
PROTO        : HTTP/1.1
RECEIVED AT  : 2024-06-17T13:23:11.262101656Z
TIME DURATION: 15m47.632783808s
HEADERS      :
	Access-Control-Allow-Credentials: true
```
This PR adds timeout for http requests so that they complete within the specified time (default 2 min, configurable using LINODE_REQUEST_TIMEOUT environment variable).

#### Steps to reproduce the issue using CAPL:
1. Provision new CAPL cluster
```
CONTROL_PLANE_MACHINE_COUNT=3 WORKER_MACHINE_COUNT=3 FW_AUDIT_ONLY=false clusterctl generate cluster vpcless --infrastructure local-linode:v0.0.0 --flavor kubeadm-vpcless | k apply -f -
```
2. Check time taken by nodes to come up and join the cluster. Third control plane node would have taken more than 12-15mins after the second control plane node joined the cluster.

#### How to test the fix
Provision CAPL cluster for vpcless flavor with linode-ccm image set to image built from this patch. I have a custom image with this patch at `docker.io/rahulait/ccm:timeout`. Once provisioned, check and see that nodes have joined the cluster without much gaps between their provisioning.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

