### PR TITLE
Bump golangci-lint to support 1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,9 @@ vet: fmt
 .PHONY: lint
 lint:
 	docker run --rm -v "$(shell pwd):/var/work:ro" -w /var/work \
-		golangci/golangci-lint:v1.57.2 golangci-lint run -v --timeout=5m
+		golangci/golangci-lint:v1.60.1 golangci-lint run -v --timeout=5m
 	docker run --rm -v "$(shell pwd):/var/work:ro" -w /var/work/e2e \
-		golangci/golangci-lint:v1.57.2 golangci-lint run -v --timeout=5m
+		golangci/golangci-lint:v1.60.1 golangci-lint run -v --timeout=5m
 
 .PHONY: fmt
 fmt:


### PR DESCRIPTION
We use 'stable' in our Github Actions and that now refers to Go 1.23, so we need a supported version of golangci-lint for that one to work.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

