### PR TITLE
Do not use a custom http.Transport due to Resty incompatibility

### DIFF
--- a/cloud/linode/client/client.go
+++ b/cloud/linode/client/client.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/linode/linodego"
-	"golang.org/x/oauth2"
 	"k8s.io/klog/v2"
 )
 
@@ -63,19 +62,13 @@ func New(token string, timeout time.Duration) (*linodego.Client, error) {
 	userAgent := fmt.Sprintf("linode-cloud-controller-manager %s", linodego.DefaultUserAgent)
 	apiURL := os.Getenv("LINODE_URL")
 
-	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	oauth2Client := &http.Client{
-		Transport: &oauth2.Transport{
-			Source: tokenSource,
-		},
-		Timeout: timeout,
-	}
-	linodeClient := linodego.NewClient(oauth2Client)
+	linodeClient := linodego.NewClient(&http.Client{Timeout: timeout})
 	client, err := linodeClient.UseURL(apiURL)
 	if err != nil {
 		return nil, err
 	}
 	client.SetUserAgent(userAgent)
+	client.SetToken(token)
 
 	klog.V(3).Infof("Linode client created with default timeout of %v", timeout)
 	return client, nil


### PR DESCRIPTION
We're hitting the same issue as here: https://github.com/linode/cluster-api-provider-linode/pull/436

When we use a custom CA, it doesn't get used.

Given that we construct an http.Transport that is of a different concrete type than http.Transport (it just needs to be a RoundTripper), resty fails and defaults to an empty client, discarding our CA.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [x] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

