### PR TITLE
[fix] don't assume the IP holder immediately reflects the new IP to share for a cilium-bgp-lb Service

### DIFF
--- a/cloud/linode/cilium_loadbalancers.go
+++ b/cloud/linode/cilium_loadbalancers.go
@@ -221,7 +221,6 @@ func (l *loadbalancers) createSharedIP(ctx context.Context, nodes []*v1.Node) (s
 	if err != nil {
 		return "", err
 	}
-	inClusterAddrs = append(inClusterAddrs, newSharedIP.Address)
 	// if any of the addrs don't exist on the ip-holder (e.g. someone manually deleted it outside the CCM),
 	// we need to exclude that from the list
 	// TODO: also clean up the CiliumLoadBalancerIPPool for that missing IP if that happens
@@ -230,7 +229,7 @@ func (l *loadbalancers) createSharedIP(ctx context.Context, nodes []*v1.Node) (s
 		klog.Infof("error getting shared IPs in cluster: %s", err.Error())
 		return "", err
 	}
-	addrs := []string{}
+	addrs := []string{newSharedIP.Address}
 	for _, i := range inClusterAddrs {
 		if slices.Contains(ipHolderAddrs, i) {
 			addrs = append(addrs, i)


### PR DESCRIPTION
Addresses edge cases where the ip-holder does not immediately reflect the new IP address that was added to perform IP sharing

### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

