### PR TITLE
[fix] getExistingSharedIPs should get Public IPs from the holder

### DIFF
--- a/cloud/linode/cilium_loadbalancers.go
+++ b/cloud/linode/cilium_loadbalancers.go
@@ -96,8 +96,8 @@ func (l *loadbalancers) getExistingSharedIPs(ctx context.Context, ipHolder *lino
 	if err != nil {
 		return nil, err
 	}
-	addrs := make([]string, 0, len(ipHolderAddrs.IPv4.Shared))
-	for _, addr := range ipHolderAddrs.IPv4.Shared {
+	addrs := make([]string, 0, len(ipHolderAddrs.IPv4.Public))
+	for _, addr := range ipHolderAddrs.IPv4.Public {
 		addrs = append(addrs, addr.Address)
 	}
 	return addrs, nil


### PR DESCRIPTION
### General:

* [X] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [X] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [X] Does your submission pass tests?
1. [X] Have you added tests? 
1. [X] Are you addressing a single feature in this PR? 
1. [X] Are your commits atomic, addressing one change per commit?
1. [X] Are you following the conventions of the language? 
1. [X] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [X] Have you explained your rationale for why this feature is needed? 
1. [X] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

### Description

Calls to `getExistingSharedIPs` should return Public IPs instead of Shared IPs, because the IPs on the holder nanode are not returned under the Shared IP's section of the API response.

fixes #231 