### PR TITLE
Get IP addresses type from Linode

### DIFF
--- a/cloud/linode/route_controller_test.go
+++ b/cloud/linode/route_controller_test.go
@@ -86,6 +86,7 @@ func TestListRoutes(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), gomock.Any()).Times(1).Return(ipsResponse(nil, nil, ""), nil)
 		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(noRoutesInVPC, nil)
 		routes, err := routeController.ListRoutes(ctx, "abc")
 		assert.NoError(t, err)
@@ -127,6 +128,7 @@ func TestListRoutes(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), gomock.Any()).Times(1).Return(ipsResponse(nil, nil, ""), nil)
 		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(routesInVPC, nil)
 		routes, err := routeController.ListRoutes(ctx, "abc")
 		assert.NoError(t, err)
@@ -168,6 +170,7 @@ func TestListRoutes(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), gomock.Any()).Times(1).Return(ipsResponse(nil, nil, ""), nil)
 		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(routesInDifferentVPC, nil)
 		routes, err := routeController.ListRoutes(ctx, "abc")
 		assert.NoError(t, err)
@@ -227,6 +230,7 @@ func TestCreateRoute(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), gomock.Any()).Times(1).Return(ipsResponse(nil, nil, ""), nil)
 		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(noRoutesInVPC, nil)
 		client.EXPECT().UpdateInstanceConfigInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&instanceConfigIntfWithVPCAndRoute, nil)
 		err = routeController.CreateRoute(ctx, "dummy", "dummy", route)
@@ -259,6 +263,7 @@ func TestCreateRoute(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), gomock.Any()).Times(1).Return(ipsResponse(nil, nil, ""), nil)
 		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(routesInVPC, nil)
 		err = routeController.CreateRoute(ctx, "dummy", "dummy", route)
 		assert.NoError(t, err)
@@ -346,6 +351,7 @@ func TestDeleteRoute(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), gomock.Any()).Times(1).Return(ipsResponse(nil, nil, ""), nil)
 		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(noRoutesInVPC, nil)
 		client.EXPECT().UpdateInstanceConfigInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&instanceConfigIntfWithVPCAndNoRoute, nil)
 		err = routeController.DeleteRoute(ctx, "dummy", route)
@@ -377,6 +383,7 @@ func TestDeleteRoute(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().GetInstanceIPAddresses(gomock.Any(), gomock.Any()).Times(1).Return(ipsResponse(nil, nil, ""), nil)
 		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(routesInVPC, nil)
 		client.EXPECT().UpdateInstanceConfigInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&instanceConfigIntfWithVPCAndNoRoute, nil)
 		err = routeController.DeleteRoute(ctx, "dummy", route)


### PR DESCRIPTION
Avoid auto-detection of private IP address - respect setting in Linode.
Needed to support testing Linode instances which are providing public IP addresses in private IP ranges. 

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

