### PR TITLE
Allow to mark internal network as external

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Environment Variable | Default | Description
 `LINODE_INSTANCE_CACHE_TTL` | `15` | Default timeout of instance cache in seconds
 `LINODE_ROUTES_CACHE_TTL_SECONDS` | `60` | Default timeout of route cache in seconds
 `LINODE_REQUEST_TIMEOUT_SECONDS` | `120` | Default timeout in seconds for http requests to linode API
-`LINODE_EXTERNAL_SUBNET` | `` | Mark private network as external. Example - `172.24.0.0/16`
+`LINODE_EXTERNAL_SUBNET` | | Mark private network as external. Example - `172.24.0.0/16`
 
 ## Generating a Manifest for Deployment
 Use the script located at `./deploy/generate-manifest.sh` to generate a self-contained deployment manifest for the Linode CCM. Two arguments are required.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Environment Variable | Default | Description
 `LINODE_INSTANCE_CACHE_TTL` | `15` | Default timeout of instance cache in seconds
 `LINODE_ROUTES_CACHE_TTL_SECONDS` | `60` | Default timeout of route cache in seconds
 `LINODE_REQUEST_TIMEOUT_SECONDS` | `120` | Default timeout in seconds for http requests to linode API
+`LINODE_EXTERNAL_SUBNET` | `` | Mark private network as external. Example - `172.24.0.0/16`
 
 ## Generating a Manifest for Deployment
 Use the script located at `./deploy/generate-manifest.sh` to generate a self-contained deployment manifest for the Linode CCM. Two arguments are required.

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -3,7 +3,7 @@ package linode
 import (
 	"fmt"
 	"io"
-	"net/netip"
+	"net"
 	"os"
 	"strconv"
 	"sync"
@@ -38,7 +38,7 @@ var Options struct {
 	VPCName               string
 	LoadBalancerType      string
 	BGPNodeSelector       string
-	LinodeExternalNetwork *netip.Prefix
+	LinodeExternalNetwork *net.IPNet
 }
 
 // vpcDetails is set when VPCName options flag is set.

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -3,6 +3,7 @@ package linode
 import (
 	"fmt"
 	"io"
+	"net/netip"
 	"os"
 	"strconv"
 	"sync"
@@ -37,6 +38,7 @@ var Options struct {
 	VPCName               string
 	LoadBalancerType      string
 	BGPNodeSelector       string
+	LinodeExternalNetwork *netip.Prefix
 }
 
 // vpcDetails is set when VPCName options flag is set.

--- a/cloud/linode/common.go
+++ b/cloud/linode/common.go
@@ -2,6 +2,8 @@ package linode
 
 import (
 	"fmt"
+	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 
@@ -41,4 +43,15 @@ func IgnoreLinodeAPIError(err error, code int) error {
 	}
 
 	return err
+}
+
+func isPrivate(ip *net.IP) bool {
+	if Options.LinodeExternalNetwork == nil {
+		return ip.IsPrivate()
+	}
+	ipAddr, err := netip.ParseAddr(ip.String())
+	if err != nil {
+		panic(err)
+	}
+	return ip.IsPrivate() && !Options.LinodeExternalNetwork.Contains(ipAddr)
 }

--- a/cloud/linode/common.go
+++ b/cloud/linode/common.go
@@ -3,7 +3,6 @@ package linode
 import (
 	"fmt"
 	"net"
-	"net/netip"
 	"strconv"
 	"strings"
 
@@ -49,9 +48,6 @@ func isPrivate(ip *net.IP) bool {
 	if Options.LinodeExternalNetwork == nil {
 		return ip.IsPrivate()
 	}
-	ipAddr, err := netip.ParseAddr(ip.String())
-	if err != nil {
-		panic(err)
-	}
-	return ip.IsPrivate() && !Options.LinodeExternalNetwork.Contains(ipAddr)
+
+	return ip.IsPrivate() && !Options.LinodeExternalNetwork.Contains(*ip)
 }

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -49,7 +49,7 @@ func (nc *nodeCache) getInstanceAddresses(instance linodego.Instance, vpcips []s
 
 	for _, ip := range instance.IPv4 {
 		ipType := v1.NodeExternalIP
-		if ip.IsPrivate() {
+		if isPrivate(ip) {
 			ipType = v1.NodeInternalIP
 		}
 		ips = append(ips, nodeIP{ip: ip.String(), ipType: ipType})
@@ -155,7 +155,7 @@ func (i *instances) linodeByIP(kNode *v1.Node) (*linodego.Instance, error) {
 	}
 	for _, node := range i.nodeCache.nodes {
 		for _, nodeIP := range node.instance.IPv4 {
-			if !nodeIP.IsPrivate() && slices.Contains(kNodeAddresses, nodeIP.String()) {
+			if !isPrivate(nodeIP) && slices.Contains(kNodeAddresses, nodeIP.String()) {
 				return node.instance, nil
 			}
 		}

--- a/cloud/linode/node_controller.go
+++ b/cloud/linode/node_controller.go
@@ -172,7 +172,7 @@ func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
 	// supports other subnets with nodebalancer, this logic needs to be updated.
 	// https://www.linode.com/docs/api/linode-instances/#linode-view
 	for _, addr := range linode.IPv4 {
-		if addr.IsPrivate() {
+		if isPrivate(addr) {
 			expectedPrivateIP = addr.String()
 			break
 		}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/netip"
 	"os"
 
 	"k8s.io/component-base/logs"
@@ -25,9 +26,10 @@ import (
 )
 
 const (
-	sentryDSNVariable         = "SENTRY_DSN"
-	sentryEnvironmentVariable = "SENTRY_ENVIRONMENT"
-	sentryReleaseVariable     = "SENTRY_RELEASE"
+	sentryDSNVariable            = "SENTRY_DSN"
+	sentryEnvironmentVariable    = "SENTRY_ENVIRONMENT"
+	sentryReleaseVariable        = "SENTRY_RELEASE"
+	linodeExternalSubnetVariable = "LINODE_EXTERNAL_SUBNET"
 )
 
 func initializeSentry() {
@@ -112,6 +114,17 @@ func main() {
 		sentry.CaptureError(ctx, fmt.Errorf(msg))
 		fmt.Fprintf(os.Stderr, "kubeconfig missing from CCM flag set"+"\n")
 		os.Exit(1)
+	}
+
+	if externalSubnet, ok := os.LookupEnv(linodeExternalSubnetVariable); ok && externalSubnet != "" {
+		network, err := netip.ParsePrefix(externalSubnet)
+		if err != nil {
+			msg := fmt.Sprintf("Unable to parse %s as network subnet: %v", externalSubnet, err)
+			sentry.CaptureError(ctx, fmt.Errorf(msg))
+			fmt.Fprintf(os.Stderr, "%v\n", msg)
+			os.Exit(1)
+		}
+		linode.Options.LinodeExternalNetwork = &network
 	}
 
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net/netip"
+	"net"
 	"os"
 
 	"k8s.io/component-base/logs"
@@ -117,14 +117,14 @@ func main() {
 	}
 
 	if externalSubnet, ok := os.LookupEnv(linodeExternalSubnetVariable); ok && externalSubnet != "" {
-		network, err := netip.ParsePrefix(externalSubnet)
+		_, network, err := net.ParseCIDR(externalSubnet)
 		if err != nil {
 			msg := fmt.Sprintf("Unable to parse %s as network subnet: %v", externalSubnet, err)
 			sentry.CaptureError(ctx, fmt.Errorf(msg))
 			fmt.Fprintf(os.Stderr, "%v\n", msg)
 			os.Exit(1)
 		}
-		linode.Options.LinodeExternalNetwork = &network
+		linode.Options.LinodeExternalNetwork = network
 	}
 
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)


### PR DESCRIPTION
With new enviroment variable `LINODE_EXTERNAL_SUBNET` is possible to set internal network subnet to be used as external network.

Useful for running on testing Linode cloud instances which are providing external IP addresses in internal network.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

