### PR TITLE
[cleanup] remove deprecated PagedResponse types from fake_linode_test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,8 +34,3 @@ linters:
     - musttag
     - exhaustive
     - nilnil
-
-issues:
-  exclude-rules:
-    - path: cloud/linode/fake_linode_test.go
-      text: 'SA1019: (.+).(NodeBalancersPagedResponse|NodeBalancerConfigsPagedResponse|NodeBalancerNodesPagedResponse|FirewallDevicesPagedResponse) is deprecated: (NodeBalancersPagedResponse|NodeBalancerConfigsPagedResponse|NodeBalancerNodesPagedResponse|FirewallDevicesPagedResponse) exists for historical compatibility and should not be used.'

--- a/cloud/linode/fake_linode_test.go
+++ b/cloud/linode/fake_linode_test.go
@@ -75,6 +75,15 @@ func (f *fakeAPI) didRequestOccur(method, path, body string) bool {
 	return ok
 }
 
+// paginatedResponse represents a single response from a paginated
+// endpoint.
+type paginatedResponse[T any] struct {
+	Page    int `json:"page"    url:"page,omitempty"`
+	Pages   int `json:"pages"   url:"pages,omitempty"`
+	Results int `json:"results" url:"results,omitempty"`
+	Data    []T `json:"data"`
+}
+
 func (f *fakeAPI) setupRoutes() {
 	f.mux.HandleFunc("GET /v4/nodebalancers", func(w http.ResponseWriter, r *http.Request) {
 		res := 0
@@ -97,13 +106,12 @@ func (f *fakeAPI) setupRoutes() {
 				}
 			}
 		}
-		resp := linodego.NodeBalancersPagedResponse{
-			PageOptions: &linodego.PageOptions{
-				Page:    1,
-				Pages:   1,
-				Results: res,
-			},
-			Data: data,
+
+		resp := paginatedResponse[linodego.NodeBalancer]{
+			Page:    1,
+			Pages:   1,
+			Results: res,
+			Data:    data,
 		}
 		rr, _ := json.Marshal(resp)
 		_, _ = w.Write(rr)
@@ -178,13 +186,11 @@ func (f *fakeAPI) setupRoutes() {
 				}
 			}
 		}
-		resp := linodego.NodeBalancerConfigsPagedResponse{
-			PageOptions: &linodego.PageOptions{
-				Page:    1,
-				Pages:   1,
-				Results: res,
-			},
-			Data: data,
+		resp := paginatedResponse[linodego.NodeBalancerConfig]{
+			Page:    1,
+			Pages:   1,
+			Results: res,
+			Data:    data,
 		}
 		rr, err := json.Marshal(resp)
 		if err != nil {
@@ -208,13 +214,11 @@ func (f *fakeAPI) setupRoutes() {
 			}
 		}
 
-		resp := linodego.NodeBalancerNodesPagedResponse{
-			PageOptions: &linodego.PageOptions{
-				Page:    1,
-				Pages:   1,
-				Results: res,
-			},
-			Data: data,
+		resp := paginatedResponse[linodego.NodeBalancerNode]{
+			Page:    1,
+			Pages:   1,
+			Results: res,
+			Data:    data,
 		}
 		rr, _ := json.Marshal(resp)
 		_, _ = w.Write(rr)
@@ -243,10 +247,7 @@ func (f *fakeAPI) setupRoutes() {
 		for i := range firewallDevices {
 			firewallDeviceList = append(firewallDeviceList, *firewallDevices[i])
 		}
-		rr, _ := json.Marshal(linodego.FirewallDevicesPagedResponse{
-			PageOptions: &linodego.PageOptions{Page: 1, Pages: 1, Results: len(firewallDeviceList)},
-			Data:        firewallDeviceList,
-		})
+		rr, _ := json.Marshal(paginatedResponse[linodego.FirewallDevice]{Page: 1, Pages: 1, Results: len(firewallDeviceList), Data: firewallDeviceList})
 		_, _ = w.Write(rr)
 	})
 


### PR DESCRIPTION
This removes types that have been deprecated in more recent versions of linodego for PagedResponses. (see https://github.com/linode/linodego/blob/v1.41.0/request_helpers.go#L13-L18)
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

