### PR TITLE
manage routes for instances in multiple vpcs in a single region

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ When running k8s clusters within VPC, node specific podCIDRs need to be allowed 
 ##### Example usage in values.yaml
 ```yaml
 routeController:
-  vpcName: <name of VPC>
+  vpcNames: <comma separated names of VPCs managed by CCM>
   clusterCIDR: 10.0.0.0/8
   configureCloudRoutes: true
 ```

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -35,7 +35,7 @@ var Options struct {
 	KubeconfigFlag        *pflag.Flag
 	LinodeGoDebug         bool
 	EnableRouteController bool
-	// deprecated: use VPCNames instead
+	// Deprecated: use VPCNames instead
 	VPCName               string
 	VPCNames              string
 	LoadBalancerType      string

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -79,17 +79,28 @@ func (nc *nodeCache) refreshInstances(ctx context.Context, client client.Client)
 
 	// If running within VPC, find instances and store their ips
 	vpcNodes := map[int][]string{}
-	vpcID := vpcInfo.getID()
-	if vpcID != 0 {
-		resp, err := client.ListVPCIPAddresses(ctx, vpcID, linodego.NewListOptions(0, ""))
-		if err != nil {
-			return err
+	vpcNames := strings.Split(Options.VPCNames, ",")
+	for _, v := range vpcNames {
+		vpcName := strings.TrimSpace(v)
+		if vpcName == "" {
+			continue
 		}
-		for _, r := range resp {
-			if r.Address == nil {
-				continue
+		vpcID, err := GetVPCID(client, strings.TrimSpace(vpcName))
+		if err != nil {
+			klog.Errorf("failed updating instances cache for VPC %s. Error: %s", vpcName, err.Error())
+			continue
+		}
+		if vpcID != 0 {
+			resp, err := client.ListVPCIPAddresses(ctx, vpcID, linodego.NewListOptions(0, ""))
+			if err != nil {
+				return err
 			}
-			vpcNodes[r.LinodeID] = append(vpcNodes[r.LinodeID], *r.Address)
+			for _, r := range resp {
+				if r.Address == nil {
+					continue
+				}
+				vpcNodes[r.LinodeID] = append(vpcNodes[r.LinodeID], *r.Address)
+			}
 		}
 	}
 
@@ -97,7 +108,7 @@ func (nc *nodeCache) refreshInstances(ctx context.Context, client client.Client)
 	for i, instance := range instances {
 
 		// if running within VPC, only store instances in cache which are part of VPC
-		if vpcID != 0 && len(vpcNodes[instance.ID]) == 0 {
+		if Options.VPCNames != "" && len(vpcNodes[instance.ID]) == 0 {
 			continue
 		}
 		node := linodeInstance{

--- a/cloud/linode/instances.go
+++ b/cloud/linode/instances.go
@@ -85,22 +85,16 @@ func (nc *nodeCache) refreshInstances(ctx context.Context, client client.Client)
 		if vpcName == "" {
 			continue
 		}
-		vpcID, err := GetVPCID(client, strings.TrimSpace(vpcName))
+		resp, err := GetVPCIPAddresses(ctx, client, vpcName)
 		if err != nil {
 			klog.Errorf("failed updating instances cache for VPC %s. Error: %s", vpcName, err.Error())
 			continue
 		}
-		if vpcID != 0 {
-			resp, err := client.ListVPCIPAddresses(ctx, vpcID, linodego.NewListOptions(0, ""))
-			if err != nil {
-				return err
+		for _, r := range resp {
+			if r.Address == nil {
+				continue
 			}
-			for _, r := range resp {
-				if r.Address == nil {
-					continue
-				}
-				vpcNodes[r.LinodeID] = append(vpcNodes[r.LinodeID], *r.Address)
-			}
+			vpcNodes[r.LinodeID] = append(vpcNodes[r.LinodeID], *r.Address)
 		}
 	}
 

--- a/cloud/linode/route_controller.go
+++ b/cloud/linode/route_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -19,28 +20,40 @@ import (
 )
 
 type routeCache struct {
-	sync.RWMutex
+	Mu         sync.RWMutex
 	routes     map[int][]linodego.VPCIP
 	lastUpdate time.Time
 	ttl        time.Duration
 }
 
+// RefreshCache checks if cache has expired and updates it accordingly
 func (rc *routeCache) refreshRoutes(ctx context.Context, client client.Client) error {
-	rc.Lock()
-	defer rc.Unlock()
+	rc.Mu.Lock()
+	defer rc.Mu.Unlock()
 
 	if time.Since(rc.lastUpdate) < rc.ttl {
 		return nil
 	}
 
 	vpcNodes := map[int][]linodego.VPCIP{}
-	vpcID := vpcInfo.getID()
-	resp, err := client.ListVPCIPAddresses(ctx, vpcID, linodego.NewListOptions(0, ""))
-	if err != nil {
-		return err
-	}
-	for _, r := range resp {
-		vpcNodes[r.LinodeID] = append(vpcNodes[r.LinodeID], r)
+	vpcNames := strings.Split(Options.VPCNames, ",")
+	for _, v := range vpcNames {
+		vpcName := strings.TrimSpace(v)
+		if vpcName == "" {
+			continue
+		}
+		vpcID, err := GetVPCID(client, strings.TrimSpace(vpcName))
+		if err != nil {
+			klog.Errorf("failed updating cache for VPC %s. Error: %s", vpcName, err.Error())
+			continue
+		}
+		resp, err := client.ListVPCIPAddresses(ctx, vpcID, linodego.NewListOptions(0, ""))
+		if err != nil {
+			return err
+		}
+		for _, r := range resp {
+			vpcNodes[r.LinodeID] = append(vpcNodes[r.LinodeID], r)
+		}
 	}
 
 	rc.routes = vpcNodes
@@ -49,7 +62,6 @@ func (rc *routeCache) refreshRoutes(ctx context.Context, client client.Client) e
 }
 
 type routes struct {
-	vpcid      int
 	client     client.Client
 	instances  *instances
 	routeCache *routeCache
@@ -64,13 +76,11 @@ func newRoutes(client client.Client) (cloudprovider.Routes, error) {
 	}
 	klog.V(3).Infof("TTL for routeCache set to %d seconds", timeout)
 
-	vpcid := vpcInfo.getID()
-	if Options.EnableRouteController && vpcid == 0 {
-		return nil, fmt.Errorf("cannot enable route controller as vpc [%s] not found", Options.VPCName)
+	if Options.EnableRouteController && Options.VPCNames == "" {
+		return nil, fmt.Errorf("cannot enable route controller as vpc-names is empty")
 	}
 
 	return &routes{
-		vpcid:     vpcid,
 		client:    client,
 		instances: newInstances(client),
 		routeCache: &routeCache{
@@ -82,8 +92,8 @@ func newRoutes(client client.Client) (cloudprovider.Routes, error) {
 
 // instanceRoutesByID returns routes for given instance id
 func (r *routes) instanceRoutesByID(id int) ([]linodego.VPCIP, error) {
-	r.routeCache.RLock()
-	defer r.routeCache.RUnlock()
+	r.routeCache.Mu.RLock()
+	defer r.routeCache.Mu.RUnlock()
 	instanceRoutes, ok := r.routeCache.routes[id]
 	if !ok {
 		return nil, fmt.Errorf("no routes found for instance %d", id)
@@ -135,22 +145,25 @@ func (r *routes) CreateRoute(ctx context.Context, clusterName string, nameHint s
 	// check already configured routes
 	intfRoutes := []string{}
 	intfVPCIP := linodego.VPCIP{}
-	for _, ir := range instanceRoutes {
-		if ir.VPCID != r.vpcid {
-			continue
-		}
 
-		if ir.Address != nil {
-			intfVPCIP = ir
-			continue
-		}
+	for _, vpcid := range GetAllVPCIDs() {
+		for _, ir := range instanceRoutes {
+			if ir.VPCID != vpcid {
+				continue
+			}
 
-		if ir.AddressRange != nil && *ir.AddressRange == route.DestinationCIDR {
-			klog.V(4).Infof("Route already exists for node %s", route.TargetNode)
-			return nil
-		}
+			if ir.Address != nil {
+				intfVPCIP = ir
+				continue
+			}
 
-		intfRoutes = append(intfRoutes, *ir.AddressRange)
+			if ir.AddressRange != nil && *ir.AddressRange == route.DestinationCIDR {
+				klog.V(4).Infof("Route already exists for node %s", route.TargetNode)
+				return nil
+			}
+
+			intfRoutes = append(intfRoutes, *ir.AddressRange)
+		}
 	}
 
 	if intfVPCIP.Address == nil {
@@ -185,21 +198,24 @@ func (r *routes) DeleteRoute(ctx context.Context, clusterName string, route *clo
 	// check already configured routes
 	intfRoutes := []string{}
 	intfVPCIP := linodego.VPCIP{}
-	for _, ir := range instanceRoutes {
-		if ir.VPCID != r.vpcid {
-			continue
-		}
 
-		if ir.Address != nil {
-			intfVPCIP = ir
-			continue
-		}
+	for _, vpcid := range GetAllVPCIDs() {
+		for _, ir := range instanceRoutes {
+			if ir.VPCID != vpcid {
+				continue
+			}
 
-		if ir.AddressRange != nil && *ir.AddressRange == route.DestinationCIDR {
-			continue
-		}
+			if ir.Address != nil {
+				intfVPCIP = ir
+				continue
+			}
 
-		intfRoutes = append(intfRoutes, *ir.AddressRange)
+			if ir.AddressRange != nil && *ir.AddressRange == route.DestinationCIDR {
+				continue
+			}
+
+			intfRoutes = append(intfRoutes, *ir.AddressRange)
+		}
 	}
 
 	if intfVPCIP.Address == nil {
@@ -234,17 +250,19 @@ func (r *routes) ListRoutes(ctx context.Context, clusterName string) ([]*cloudpr
 		}
 
 		// check for configured routes
-		for _, ir := range instanceRoutes {
-			if ir.Address != nil || ir.VPCID != r.vpcid {
-				continue
-			}
-
-			if ir.AddressRange != nil {
-				route := &cloudprovider.Route{
-					TargetNode:      types.NodeName(instance.Label),
-					DestinationCIDR: *ir.AddressRange,
+		for _, vpcid := range GetAllVPCIDs() {
+			for _, ir := range instanceRoutes {
+				if ir.Address != nil || ir.VPCID != vpcid {
+					continue
 				}
-				configuredRoutes = append(configuredRoutes, route)
+
+				if ir.AddressRange != nil {
+					route := &cloudprovider.Route{
+						TargetNode:      types.NodeName(instance.Label),
+						DestinationCIDR: *ir.AddressRange,
+					}
+					configuredRoutes = append(configuredRoutes, route)
+				}
 			}
 		}
 	}

--- a/cloud/linode/route_controller.go
+++ b/cloud/linode/route_controller.go
@@ -27,12 +27,12 @@ type routeCache struct {
 }
 
 // RefreshCache checks if cache has expired and updates it accordingly
-func (rc *routeCache) refreshRoutes(ctx context.Context, client client.Client) error {
+func (rc *routeCache) refreshRoutes(ctx context.Context, client client.Client) {
 	rc.Mu.Lock()
 	defer rc.Mu.Unlock()
 
 	if time.Since(rc.lastUpdate) < rc.ttl {
-		return nil
+		return
 	}
 
 	vpcNodes := map[int][]linodego.VPCIP{}
@@ -42,14 +42,10 @@ func (rc *routeCache) refreshRoutes(ctx context.Context, client client.Client) e
 		if vpcName == "" {
 			continue
 		}
-		vpcID, err := GetVPCID(client, strings.TrimSpace(vpcName))
+		resp, err := GetVPCIPAddresses(ctx, client, vpcName)
 		if err != nil {
 			klog.Errorf("failed updating cache for VPC %s. Error: %s", vpcName, err.Error())
 			continue
-		}
-		resp, err := client.ListVPCIPAddresses(ctx, vpcID, linodego.NewListOptions(0, ""))
-		if err != nil {
-			return err
 		}
 		for _, r := range resp {
 			vpcNodes[r.LinodeID] = append(vpcNodes[r.LinodeID], r)
@@ -58,7 +54,6 @@ func (rc *routeCache) refreshRoutes(ctx context.Context, client client.Client) e
 
 	rc.routes = vpcNodes
 	rc.lastUpdate = time.Now()
-	return nil
 }
 
 type routes struct {
@@ -104,10 +99,7 @@ func (r *routes) instanceRoutesByID(id int) ([]linodego.VPCIP, error) {
 // getInstanceRoutes returns routes for given instance id
 // It refreshes routeCache if it has expired
 func (r *routes) getInstanceRoutes(ctx context.Context, id int) ([]linodego.VPCIP, error) {
-	if err := r.routeCache.refreshRoutes(ctx, r.client); err != nil {
-		return nil, err
-	}
-
+	r.routeCache.refreshRoutes(ctx, r.client)
 	return r.instanceRoutesByID(id)
 }
 

--- a/cloud/linode/route_controller_test.go
+++ b/cloud/linode/route_controller_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 func TestListRoutes(t *testing.T) {
-	Options.VPCNames = "test"
+	Options.VPCNames = "test,abc"
 	vpcIDs["test"] = 1
+	vpcIDs["abc"] = 2
 	Options.EnableRouteController = true
 
 	nodeID := 123
@@ -36,7 +37,7 @@ func TestListRoutes(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), gomock.Any()).Times(1).Return([]linodego.Instance{}, nil)
-		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]linodego.VPCIP{}, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return([]linodego.VPCIP{}, nil)
 		routes, err := routeController.ListRoutes(ctx, "test")
 		assert.NoError(t, err)
 		assert.Empty(t, routes)
@@ -59,7 +60,7 @@ func TestListRoutes(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
-		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return([]linodego.VPCIP{}, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return([]linodego.VPCIP{}, nil)
 		routes, err := routeController.ListRoutes(ctx, "test")
 		assert.NoError(t, err)
 		assert.Empty(t, routes)
@@ -85,7 +86,7 @@ func TestListRoutes(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
-		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(noRoutesInVPC, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(noRoutesInVPC, nil)
 		routes, err := routeController.ListRoutes(ctx, "test")
 		assert.NoError(t, err)
 		assert.Empty(t, routes)
@@ -126,7 +127,7 @@ func TestListRoutes(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
-		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(routesInVPC, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(routesInVPC, nil)
 		routes, err := routeController.ListRoutes(ctx, "test")
 		assert.NoError(t, err)
 		assert.NotEmpty(t, routes)
@@ -167,10 +168,72 @@ func TestListRoutes(t *testing.T) {
 		assert.NoError(t, err)
 
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
-		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(routesInDifferentVPC, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(4).Return(routesInDifferentVPC, nil)
 		routes, err := routeController.ListRoutes(ctx, "test")
 		assert.NoError(t, err)
 		assert.Empty(t, routes)
+	})
+
+	t.Run("should return routes if multiple instances exists, connected to VPCs and ip_ranges configured", func(t *testing.T) {
+		ctx := context.Background()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mocks.NewMockClient(ctrl)
+		routeController, err := newRoutes(client)
+		assert.NoError(t, err)
+
+		vpcIP2 := "10.0.0.3"
+		addressRange3 := "10.192.40.0/24"
+		addressRange4 := "10.192.50.0/24"
+
+		validInstance2 := linodego.Instance{
+			ID:     124,
+			Label:  "mock-instance2",
+			Type:   linodeType,
+			Region: region,
+			IPv4:   []*net.IP{&publicIPv4, &privateIPv4},
+		}
+
+		routesInVPC2 := []linodego.VPCIP{
+			{
+				Address:      &vpcIP2,
+				AddressRange: nil,
+				VPCID:        vpcIDs["abc"],
+				NAT1To1:      nil,
+				LinodeID:     124,
+			},
+			{
+				Address:      nil,
+				AddressRange: &addressRange3,
+				VPCID:        vpcIDs["abc"],
+				NAT1To1:      nil,
+				LinodeID:     124,
+			},
+			{
+				Address:      nil,
+				AddressRange: &addressRange4,
+				VPCID:        vpcIDs["abc"],
+				NAT1To1:      nil,
+				LinodeID:     124,
+			},
+		}
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance, validInstance2}, nil)
+		c1 := client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(routesInVPC, nil)
+		c2 := client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).After(c1).Times(1).Return(routesInVPC2, nil)
+		c3 := client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).After(c2).Times(1).Return(routesInVPC, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).After(c3).Times(1).Return(routesInVPC2, nil)
+		routes, err := routeController.ListRoutes(ctx, "test")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, routes)
+		cidrs := make([]string, len(routes))
+		for i, value := range routes {
+			cidrs[i] = value.DestinationCIDR
+		}
+		assert.Contains(t, cidrs, addressRange1)
+		assert.Contains(t, cidrs, addressRange2)
+		assert.Contains(t, cidrs, addressRange3)
+		assert.Contains(t, cidrs, addressRange4)
 	})
 }
 

--- a/cloud/linode/vpc.go
+++ b/cloud/linode/vpc.go
@@ -3,9 +3,16 @@ package linode
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/linode/linode-cloud-controller-manager/cloud/linode/client"
 	"github.com/linode/linodego"
+)
+
+var (
+	Mu sync.RWMutex
+	// vpcIDs map stores vpc id's for given vpc labels
+	vpcIDs = make(map[string]int, 0)
 )
 
 type vpcLookupError struct {
@@ -16,14 +23,33 @@ func (e vpcLookupError) Error() string {
 	return fmt.Sprintf("failed to find VPC: %q", e.value)
 }
 
-// getVPCID returns the VPC id using the VPC label
-func getVPCID(client client.Client, vpcName string) (int, error) {
+// GetAllVPCIDs returns vpc ids stored in map
+func GetAllVPCIDs() []int {
+	Mu.Lock()
+	defer Mu.Unlock()
+	values := make([]int, 0, len(vpcIDs))
+	for _, v := range vpcIDs {
+		values = append(values, v)
+	}
+	return values
+}
+
+// GetVPCID returns the VPC id of given VPC label
+func GetVPCID(client client.Client, vpcName string) (int, error) {
+	Mu.Lock()
+	defer Mu.Unlock()
+
+	// check if map contains vpc id for given label
+	if vpcid, ok := vpcIDs[vpcName]; ok {
+		return vpcid, nil
+	}
 	vpcs, err := client.ListVPCs(context.TODO(), &linodego.ListOptions{})
 	if err != nil {
 		return 0, err
 	}
 	for _, vpc := range vpcs {
 		if vpc.Label == vpcName {
+			vpcIDs[vpcName] = vpc.ID
 			return vpc.ID, nil
 		}
 	}

--- a/cloud/linode/vpc.go
+++ b/cloud/linode/vpc.go
@@ -3,6 +3,7 @@ package linode
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -66,7 +67,7 @@ func GetVPCIPAddresses(ctx context.Context, client client.Client, vpcName string
 	}
 	resp, err := client.ListVPCIPAddresses(ctx, vpcID, linodego.NewListOptions(0, ""))
 	if err != nil {
-		if strings.Contains(err.Error(), "Not found") {
+		if linodego.ErrHasStatus(err, http.StatusNotFound) {
 			Mu.Lock()
 			defer Mu.Unlock()
 			klog.Errorf("vpc %s not found. Deleting entry from cache", vpcName)

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -38,7 +38,12 @@ spec:
             {{- end }}
             {{- if .Values.routeController }}
             - --enable-route-controller=true
-            - --vpc-name={{ required "A valid .Values.routeController.vpcName is required" .Values.routeController.vpcName }}
+            {{- if .Values.routeController.vpcName }}
+            - --vpc-name={{ "A valid .Values.routeController.vpcName is required" .Values.routeController.vpcName }}
+            {{- end }}
+            {{- if .Values.routeController.vpcNames }}
+            - --vpc-names={{ "A valid .Values.routeController.vpcNames is required" .Values.routeController.vpcNames }}
+            {{- end }}
             - --configure-cloud-routes={{ default true .Values.routeController.configureCloudRoutes }}
             - --cluster-cidr={{ required "A valid .Values.routeController.clusterCIDR is required" .Values.routeController.clusterCIDR }}
             {{- if .Values.routeController.routeReconciliationPeriod }}

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -38,6 +38,12 @@ spec:
             {{- end }}
             {{- if .Values.routeController }}
             - --enable-route-controller=true
+            {{- if and .Values.routeController.vpcName .Values.routeController.vpcNames }}
+            {{- fail "Both vpcName and vpcNames are set. Please use only vpcNames." }}
+            {{- end }}
+            {{- if not (or .Values.routeController.vpcName .Values.routeController.vpcNames) }}
+            {{- fail "Neither vpcName nor vpcNames is set. Please set one of them." }}
+            {{- end }}
             {{- if .Values.routeController.vpcName }}
             - --vpc-name={{ .Values.routeController.vpcName }}
             {{- end }}

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -39,10 +39,10 @@ spec:
             {{- if .Values.routeController }}
             - --enable-route-controller=true
             {{- if .Values.routeController.vpcName }}
-            - --vpc-name={{ "A valid .Values.routeController.vpcName is required" .Values.routeController.vpcName }}
+            - --vpc-name={{ .Values.routeController.vpcName }}
             {{- end }}
             {{- if .Values.routeController.vpcNames }}
-            - --vpc-names={{ "A valid .Values.routeController.vpcNames is required" .Values.routeController.vpcNames }}
+            - --vpc-names={{ .Values.routeController.vpcNames }}
             {{- end }}
             - --configure-cloud-routes={{ default true .Values.routeController.configureCloudRoutes }}
             - --cluster-cidr={{ required "A valid .Values.routeController.clusterCIDR is required" .Values.routeController.clusterCIDR }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -51,7 +51,8 @@ tolerations:
 
 # This section adds ability to enable route-controller for ccm
 # routeController:
-#   vpcName: <name of VPC>
+#   vpcName: <name of VPC> [Deprecated: use vpcNames instead]
+#   vpcNames: <comma separated list of vpc names>
 #   clusterCIDR: 10.0.0.0/8
 #   configureCloudRoutes: true
 

--- a/main.go
+++ b/main.go
@@ -81,7 +81,8 @@ func main() {
 	// Add Linode-specific flags
 	command.Flags().BoolVar(&linode.Options.LinodeGoDebug, "linodego-debug", false, "enables debug output for the LinodeAPI wrapper")
 	command.Flags().BoolVar(&linode.Options.EnableRouteController, "enable-route-controller", false, "enables route_controller for ccm")
-	command.Flags().StringVar(&linode.Options.VPCName, "vpc-name", "", "vpc name whose routes will be managed by route-controller")
+	command.Flags().StringVar(&linode.Options.VPCName, "vpc-name", "", "[deprecated] vpc name whose routes will be managed by route-controller")
+	command.Flags().StringVar(&linode.Options.VPCNames, "vpc-names", "", "comma separated vpc names whose routes will be managed by route-controller")
 	command.Flags().StringVar(&linode.Options.LoadBalancerType, "load-balancer-type", "nodebalancer", "configures which type of load-balancing to use for LoadBalancer Services (options: nodebalancer, cilium-bgp)")
 	command.Flags().StringVar(&linode.Options.BGPNodeSelector, "bgp-node-selector", "", "node selector to use to perform shared IP fail-over with BGP (e.g. cilium-bgp-peering=true")
 

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	// Add Linode-specific flags
 	command.Flags().BoolVar(&linode.Options.LinodeGoDebug, "linodego-debug", false, "enables debug output for the LinodeAPI wrapper")
 	command.Flags().BoolVar(&linode.Options.EnableRouteController, "enable-route-controller", false, "enables route_controller for ccm")
-	command.Flags().StringVar(&linode.Options.VPCName, "vpc-name", "", "[deprecated] vpc name whose routes will be managed by route-controller")
+	command.Flags().StringVar(&linode.Options.VPCName, "vpc-name", "", "[deprecated: use vpc-names instead] vpc name whose routes will be managed by route-controller")
 	command.Flags().StringVar(&linode.Options.VPCNames, "vpc-names", "", "comma separated vpc names whose routes will be managed by route-controller")
 	command.Flags().StringVar(&linode.Options.LoadBalancerType, "load-balancer-type", "nodebalancer", "configures which type of load-balancing to use for LoadBalancer Services (options: nodebalancer, cilium-bgp)")
 	command.Flags().StringVar(&linode.Options.BGPNodeSelector, "bgp-node-selector", "", "node selector to use to perform shared IP fail-over with BGP (e.g. cilium-bgp-peering=true")


### PR DESCRIPTION
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

This PR enables route-controller to manage instances running in multiple vpcs. All these instances should still be part of a single k8s cluster where the CCM is running.
This change introduces a new flag `vpc-names` which is a comma separated list of vpc names which will be managed by the CCM's route-controller. Old flag `vpc-name` is now deprecated and will be removed in future releases.

### To test changes:
Changes in this branch are present in helm chart here: https://github.com/rahulait/linode-cloud-controller-manager/releases/tag/helm-v0.4.16

If one wants to test these changes, simply use helm repo https://rahulait.github.io/linode-cloud-controller-manager/ with version v0.4.16 to test the changes before we merge this branch to main.

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

