### PR TITLE
[test] : fix random failures in e2e tests due to curl error

### DIFF
--- a/e2e/test/fw-use-specified-nb/chainsaw-test.yaml
+++ b/e2e/test/fw-use-specified-nb/chainsaw-test.yaml
@@ -103,7 +103,7 @@ spec:
                   fwconfig=$(curl -s \
                     -H "Authorization: Bearer $LINODE_TOKEN" \
                     -H "Content-Type: application/json" \
-                    "https://api.linode.com/v4/networking/firewalls/$fwid")
+                    "https://api.linode.com/v4/networking/firewalls/$fwid" || true)
 
                   fw_attached_to_nb=$(echo $fwconfig | jq ".entities[] | select(.id == $nbid) | .id == $nbid")
 

--- a/e2e/test/lb-http-body-health-check/chainsaw-test.yaml
+++ b/e2e/test/lb-http-body-health-check/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
                   nbconfig=$(curl -s \
                     -H "Authorization: Bearer $LINODE_TOKEN" \
                     -H "Content-Type: application/json" \
-                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[] | select(.port == 80)')
+                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[] | select(.port == 80)' || true)
 
                   if [[ -z $nbconfig ]]; then
                       echo "Failed fetching nodebalancer config for port 80"

--- a/e2e/test/lb-http-status-health-check/chainsaw-test.yaml
+++ b/e2e/test/lb-http-status-health-check/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
                   nbconfig=$(curl -s \
                     -H "Authorization: Bearer $LINODE_TOKEN" \
                     -H "Content-Type: application/json" \
-                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[] | select(.port == 80)')
+                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[] | select(.port == 80)' || true)
 
                   if [[ -z $nbconfig ]]; then
                       echo "Failed fetching nodebalancer config for port 80"

--- a/e2e/test/lb-passive-health-check/chainsaw-test.yaml
+++ b/e2e/test/lb-passive-health-check/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
                   nbconfig=$(curl -s \
                     -H "Authorization: Bearer $LINODE_TOKEN" \
                     -H "Content-Type: application/json" \
-                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[] | select(.port == 80)')
+                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[] | select(.port == 80)' || true)
 
                   if [[ -z $nbconfig ]]; then
                       echo "Failed fetching nodebalancer config for port 80"

--- a/e2e/test/lb-tcp-connection-health-check/chainsaw-test.yaml
+++ b/e2e/test/lb-tcp-connection-health-check/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
                   nbconfig=$(curl -s \
                     -H "Authorization: Bearer $LINODE_TOKEN" \
                     -H "Content-Type: application/json" \
-                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[] | select(.port == 80)')
+                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[] | select(.port == 80)' || true)
 
                   if [[ -z $nbconfig ]]; then
                       echo "Failed fetching nodebalancer config for port 80"

--- a/e2e/test/lb-with-http-to-https/chainsaw-test.yaml
+++ b/e2e/test/lb-with-http-to-https/chainsaw-test.yaml
@@ -75,8 +75,8 @@ spec:
               IP=$(kubectl get svc svc-test -n $NAMESPACE -o json | jq -r .status.loadBalancer.ingress[0].ip)
 
               for i in {1..10}; do
-                  port_80=$(curl -s $IP:80 | grep "test-")
-                  port_443=$(curl --resolve linode.test:443:$IP --cacert ../certificates/ca.crt -s https://linode.test:443 | grep "test-")
+                  port_80=$(curl -s $IP:80 | grep "test-" || true)
+                  port_443=$(curl --resolve linode.test:443:$IP --cacert ../certificates/ca.crt -s https://linode.test:443 | grep "test-" || true)
 
                   if [[ -z $port_80 || -z $port_443 ]]; then
                       sleep 20

--- a/e2e/test/lb-with-multiple-http-https-ports/chainsaw-test.yaml
+++ b/e2e/test/lb-with-multiple-http-https-ports/chainsaw-test.yaml
@@ -67,10 +67,10 @@ spec:
               IP=$(kubectl get svc svc-test -n $NAMESPACE -o json | jq -r .status.loadBalancer.ingress[0].ip)
 
               for i in {1..10}; do
-                  port_80=$(curl -s $IP:80 | grep "test-")
-                  port_8080=$(curl -s $IP:8080 | grep "test-")
-                  port_443=$(curl --resolve linode.test:443:$IP --cacert ../certificates/ca.crt -s https://linode.test:443 | grep "test-")
-                  port_8443=$(curl --resolve linode.test:8443:$IP --cacert ../certificates/ca.crt -s https://linode.test:8443 | grep "test-")
+                  port_80=$(curl -s $IP:80 | grep "test-" || true)
+                  port_8080=$(curl -s $IP:8080 | grep "test-" || true)
+                  port_443=$(curl --resolve linode.test:443:$IP --cacert ../certificates/ca.crt -s https://linode.test:443 | grep "test-" || true)
+                  port_8443=$(curl --resolve linode.test:8443:$IP --cacert ../certificates/ca.crt -s https://linode.test:8443 | grep "test-" || true)
 
                   if [[ -z $port_80 || -z $port_8080 || -z $port_443 || -z $port_8443 ]]; then
                       sleep 15

--- a/e2e/test/lb-with-node-addition/chainsaw-test.yaml
+++ b/e2e/test/lb-with-node-addition/chainsaw-test.yaml
@@ -78,7 +78,7 @@ spec:
                   nbconfig=$(curl -s \
                     -H "Authorization: Bearer $LINODE_TOKEN" \
                     -H "Content-Type: application/json" \
-                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[]? | select(.port == 80)')
+                    "https://api.linode.com/v4/nodebalancers/$nbid/configs" | jq '.data[]? | select(.port == 80)' || true)
 
                   if [[ -z $nbconfig ]]; then
                       echo "Failed fetching nodebalancer config for port 80"


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:
Sometimes, e2e test would fail even if its within a forloop block to retry few times. If curl command returned non-zero code, it would result in script to fail. With these fixes, we are now letting code to retry few times based on the for loop.
* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

