### PR TITLE
[improvement] set securityContext and use affinity instead of nodeSelector

### DIFF
--- a/deploy/ccm-linode-template.yaml
+++ b/deploy/ccm-linode-template.yaml
@@ -77,10 +77,17 @@ spec:
       labels:
         app: ccm-linode
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: ccm-linode
-      nodeSelector:
-        # The CCM will only run on a Node labelled as a master, you may want to change this
-        node-role.kubernetes.io/control-plane: ""
       tolerations:
         # The CCM can run on Nodes tainted as masters
         - key: "node-role.kubernetes.io/control-plane"
@@ -122,6 +129,11 @@ spec:
                 secretKeyRef:
                   name: ccm-linode
                   key: region
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
       volumes:
       - name: k8s
         hostPath:

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -15,13 +15,21 @@ spec:
         app: ccm-linode
     spec:
       serviceAccountName: ccm-linode
-      {{- if .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- with .Values.securityContext }}
+      securityContext:
+      {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.tolerations }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: true
       containers:
@@ -33,8 +41,8 @@ spec:
             - --v=3
             - --secure-port=10253
             - --webhook-secure-port=0
-            {{- if .Values.linodegoDebug }}
-            - --linodego-debug={{ .Values.linodegoDebug }}
+            {{- with .Values.linodegoDebug }}
+            - --linodego-debug={{ . }}
             {{- end }}
             {{- if .Values.routeController }}
             - --enable-route-controller=true
@@ -44,36 +52,40 @@ spec:
             {{- if not (or .Values.routeController.vpcName .Values.routeController.vpcNames) }}
             {{- fail "Neither vpcName nor vpcNames is set. Please set one of them." }}
             {{- end }}
-            {{- if .Values.routeController.vpcName }}
-            - --vpc-name={{ .Values.routeController.vpcName }}
+            {{- with .Values.routeController.vpcName }}
+            - --vpc-name={{ . }}
             {{- end }}
-            {{- if .Values.routeController.vpcNames }}
-            - --vpc-names={{ .Values.routeController.vpcNames }}
+            {{- with .Values.routeController.vpcNames }}
+            - --vpc-names={{ . }}
             {{- end }}
             - --configure-cloud-routes={{ default true .Values.routeController.configureCloudRoutes }}
             - --cluster-cidr={{ required "A valid .Values.routeController.clusterCIDR is required" .Values.routeController.clusterCIDR }}
-            {{- if .Values.routeController.routeReconciliationPeriod }}
-            - --route-reconciliation-period={{ .Values.routeController.routeReconciliationPeriod }}
+            {{- with .Values.routeController.routeReconciliationPeriod }}
+            - --route-reconciliation-period={{ . }}
             {{- end }}
             {{- end }}
             {{- if .Values.sharedIPLoadBalancing }}
-            {{- if .Values.sharedIPLoadBalancing.bgpNodeSelector }}
-            - --bgp-node-selector={{ .Values.sharedIPLoadBalancing.bgpNodeSelector }}
+            {{- with .Values.sharedIPLoadBalancing.bgpNodeSelector }}
+            - --bgp-node-selector={{ . }}
             {{- end }}
-            {{- if .Values.sharedIPLoadBalancing.ipHolderSuffix }}
-            - --ip-holder-suffix={{ .Values.sharedIPLoadBalancing.ipHolderSuffix }}
+            {{- with .Values.sharedIPLoadBalancing.ipHolderSuffix }}
+            - --ip-holder-suffix={{ . }}
             {{- end}}
             - --load-balancer-type={{ required "A valid .Values.sharedIPLoadBalancing.loadBalancerType is required for shared IP load-balancing" .Values.sharedIPLoadBalancing.loadBalancerType }}
             {{- end }}
-            {{- if .Values.tokenHealthChecker }}
-            - --enable-token-health-checker={{ .Values.tokenHealthChecker }}
+            {{- with .Values.tokenHealthChecker }}
+            - --enable-token-health-checker={{ . }}
             {{- end }}
-            {{- if .Values.nodeBalancerTags }}
-            - --nodebalancer-tags={{ join " " .Values.nodeBalancerTags }}
+            {{- with .Values.nodeBalancerTags }}
+            - --nodebalancer-tags={{ join " " . }}
             {{- end }}
             {{- if .Values.allowUnauthorizedMetrics }}
             - --authorization-always-allow-paths="/metrics"
             {{- end }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/kubernetes
               name: k8s

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -10,10 +10,27 @@ region: ""
 #   apiTokenRef: "apiToken"
 #   regionRef: "region"
 
-# node-role.kubernetes.io/master - if set true, it deploys the svc on the master node
-nodeSelector:
-  # The CCM will only run on a Node labelled as a master, you may want to change this
-  node-role.kubernetes.io/control-plane: ""
+# Ensures the CCM runs on control plane nodes
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+
+# DEPRECATED: use affinity instead
+nodeSelector: {}
+
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
 
 # Image repository must be 'linode/linode-cloud-controller-manager'. The tag can be changed/set to various ccm versions.
 # The pullPolicy is set to Always but can be changed when it is not required to always pull the new image


### PR DESCRIPTION
This PR adds compatibility for clusters running RKE2 on top of Linode infrastructure without needing to modify the manifests or helm chart values. Security contexts are set for the case of running with CIS hardening on RKE2 clusters.
 
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

