### PR TITLE
[improvement] Allow setting vpcName(s) without enabling route controller

### DIFF
--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -44,25 +44,33 @@ spec:
             {{- with .Values.linodegoDebug }}
             - --linodego-debug={{ . }}
             {{- end }}
-            {{- if .Values.routeController }}
-            - --enable-route-controller=true
-            {{- if and .Values.routeController.vpcName .Values.routeController.vpcNames }}
+            {{- $vpcNames := .Values.vpcNames }}
+            {{- if and .Values.routeController .Values.routeController.vpcNames }}
+            {{- $vpcNames = .Values.routeController.vpcNames }}
+            {{- end }}
+            {{- $vpcName := .Values.vpcName }}
+            {{- if and .Values.routeController .Values.routeController.vpcName }}
+            {{- $vpcName = .Values.routeController.vpcName }}
+            {{- end }}
+            {{- if and $vpcName $vpcNames }}
             {{- fail "Both vpcName and vpcNames are set. Please use only vpcNames." }}
             {{- end }}
-            {{- if not (or .Values.routeController.vpcName .Values.routeController.vpcNames) }}
+            {{- if .Values.routeController }}
+            - --enable-route-controller=true
+            {{- if not (or $vpcName $vpcNames) }}
             {{- fail "Neither vpcName nor vpcNames is set. Please set one of them." }}
-            {{- end }}
-            {{- with .Values.routeController.vpcName }}
-            - --vpc-name={{ . }}
-            {{- end }}
-            {{- with .Values.routeController.vpcNames }}
-            - --vpc-names={{ . }}
             {{- end }}
             - --configure-cloud-routes={{ default true .Values.routeController.configureCloudRoutes }}
             - --cluster-cidr={{ required "A valid .Values.routeController.clusterCIDR is required" .Values.routeController.clusterCIDR }}
             {{- with .Values.routeController.routeReconciliationPeriod }}
             - --route-reconciliation-period={{ . }}
             {{- end }}
+            {{- end }}
+            {{- with $vpcNames }}
+            - --vpc-names={{ . }}
+            {{- end }}
+            {{- with $vpcName }}
+            - --vpc-name={{ . }}
             {{- end }}
             {{- if .Values.sharedIPLoadBalancing }}
             {{- with .Values.sharedIPLoadBalancing.bgpNodeSelector }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -74,6 +74,10 @@ tolerations:
 #   clusterCIDR: 10.0.0.0/8
 #   configureCloudRoutes: true
 
+# vpcs that node internal IPs will be assigned from (not required if already specified in routeController)
+# vpcName: <name of VPC> [Deprecated: use vpcNames instead]
+# vpcNames: <comma separated list of vpc names>
+
 # Enable Linode token health checker
 # tokenHealthChecker: true
 

--- a/docs/getting-started/helm-installation.md
+++ b/docs/getting-started/helm-installation.md
@@ -25,6 +25,10 @@ routeController:
   clusterCIDR: "10.0.0.0/8"
   configureCloudRoutes: true
 
+# Optional: Assign node internal IPs from VPCs without enabling route controller
+# Not required if specified in routeController
+vpcNames: "" # Comma separated VPC names
+
 # Optional: Configure shared IP load balancing instead of NodeBalancers (requires Cilium CNI and BGP Control Plane enabled)
 sharedIPLoadBalancing:
   loadBalancerType: cilium-bgp


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

This PR allows Helm chart consumers to set `vpcName(s)` without enabling the route controller. The chart will still error if `routeController` is set to true but no VPC is specified. This change allows the node controller to only cache nodes that belong to given VPCs without enabling route controller functionality. 