### PR TITLE
[fix] : use latest node object when processing node update request

### DIFF
--- a/cloud/linode/instances_test.go
+++ b/cloud/linode/instances_test.go
@@ -17,7 +17,6 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 
 	"github.com/linode/linode-cloud-controller-manager/cloud/linode/client/mocks"
-
 )
 
 const (

--- a/cloud/linode/node_controller.go
+++ b/cloud/linode/node_controller.go
@@ -103,8 +103,9 @@ func (s *nodeController) Run(stopCh <-chan struct{}) {
 func (s *nodeController) addNodeToQueue(node *v1.Node) {
 	s.Lock()
 	defer s.Unlock()
-	s.nodeLastAdded[node.Name] = time.Now()
-	s.queue.Add(nodeRequest{node: node, timestamp: time.Now()})
+	currTime := time.Now()
+	s.nodeLastAdded[node.Name] = currTime
+	s.queue.Add(nodeRequest{node: node, timestamp: currTime})
 }
 
 // worker runs a worker thread that dequeues new or modified nodes and processes

--- a/cloud/linode/node_controller_test.go
+++ b/cloud/linode/node_controller_test.go
@@ -100,6 +100,16 @@ func TestNodeController_processNext(t *testing.T) {
 		}
 	})
 
+	t.Run("should return no error if timestamp for node being processed is older than the most recent request", func(t *testing.T) {
+		controller.addNodeToQueue(node)
+		controller.nodeLastAdded["test"] = time.Now().Add(controller.ttl)
+		result := controller.processNext()
+		assert.True(t, result, "processNext should return true")
+		if queue.Len() != 0 {
+			t.Errorf("expected queue to be empty, got %d items", queue.Len())
+		}
+	})
+
 	t.Run("should return no error if node exists", func(t *testing.T) {
 		controller.addNodeToQueue(node)
 		publicIP := net.ParseIP("172.234.31.123")

--- a/cloud/linode/node_controller_test.go
+++ b/cloud/linode/node_controller_test.go
@@ -28,7 +28,7 @@ func TestNodeController_Run(t *testing.T) {
 	client := mocks.NewMockClient(ctrl)
 	kubeClient := fake.NewSimpleClientset()
 	informer := informers.NewSharedInformerFactory(kubeClient, 0).Core().V1().Nodes()
-	mockQueue := workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[any]{Name: "test"})
+	mockQueue := workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[nodeRequest]{Name: "test"})
 
 	nodeCtrl := newNodeController(kubeClient, client, informer, newInstances(client))
 	nodeCtrl.queue = mockQueue
@@ -68,7 +68,7 @@ func TestNodeController_processNext(t *testing.T) {
 	defer ctrl.Finish()
 	client := mocks.NewMockClient(ctrl)
 	kubeClient := fake.NewSimpleClientset()
-	queue := workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[any]{Name: "testQueue"})
+	queue := workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[nodeRequest]{Name: "testQueue"})
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "test",
@@ -87,10 +87,11 @@ func TestNodeController_processNext(t *testing.T) {
 		queue:              queue,
 		metadataLastUpdate: make(map[string]time.Time),
 		ttl:                defaultMetadataTTL,
+		nodeLastAdded:      make(map[string]time.Time),
 	}
 
 	t.Run("should return no error on unknown errors", func(t *testing.T) {
-		queue.Add(node)
+		controller.addNodeToQueue(node)
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{}, errors.New("lookup failed"))
 		result := controller.processNext()
 		assert.True(t, result, "processNext should return true")
@@ -100,7 +101,7 @@ func TestNodeController_processNext(t *testing.T) {
 	})
 
 	t.Run("should return no error if node exists", func(t *testing.T) {
-		queue.Add(node)
+		controller.addNodeToQueue(node)
 		publicIP := net.ParseIP("172.234.31.123")
 		privateIP := net.ParseIP("192.168.159.135")
 		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
@@ -113,17 +114,8 @@ func TestNodeController_processNext(t *testing.T) {
 		}
 	})
 
-	t.Run("should return no error if queued object is not of type Node", func(t *testing.T) {
-		queue.Add("abc")
-		result := controller.processNext()
-		assert.True(t, result, "processNext should return true")
-		if queue.Len() != 0 {
-			t.Errorf("expected queue to be empty, got %d items", queue.Len())
-		}
-	})
-
 	t.Run("should return no error if node in k8s doesn't exist", func(t *testing.T) {
-		queue.Add(node)
+		controller.addNodeToQueue(node)
 		controller.kubeclient = fake.NewSimpleClientset()
 		defer func() { controller.kubeclient = kubeClient }()
 		result := controller.processNext()
@@ -134,9 +126,9 @@ func TestNodeController_processNext(t *testing.T) {
 	})
 
 	t.Run("should return error and requeue when it gets 429 from linode API", func(t *testing.T) {
-		queue = workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[any]{Name: "testQueue1"})
-		queue.Add(node)
+		queue = workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[nodeRequest]{Name: "testQueue1"})
 		controller.queue = queue
+		controller.addNodeToQueue(node)
 		client := mocks.NewMockClient(ctrl)
 		controller.instances = newInstances(client)
 		retryInterval = 1 * time.Nanosecond
@@ -150,9 +142,9 @@ func TestNodeController_processNext(t *testing.T) {
 	})
 
 	t.Run("should return error and requeue when it gets error >= 500 from linode API", func(t *testing.T) {
-		queue = workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[any]{Name: "testQueue2"})
-		queue.Add(node)
+		queue = workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[nodeRequest]{Name: "testQueue2"})
 		controller.queue = queue
+		controller.addNodeToQueue(node)
 		client := mocks.NewMockClient(ctrl)
 		controller.instances = newInstances(client)
 		retryInterval = 1 * time.Nanosecond


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:
This PR now makes sure most recent node request is processed. Currently, in case of 429 or 5XX errors, we are re-queueing the request after a minute to retry again. If linodeAPI is down for some reason or we are getting rate limited, those requests will get re-queued. We also get node update requests every 5 mins and if they also fail, they also end up getting queued. We saw that we were making multiple requests again and again which kept on increasing over time when we encountered 429 or 5XX API errors. This PR addresses that and keeps track of time when the most recent node update request was made for a node. All prior requests which are in queue or are waiting to be queued due to AddAfter() will get ignored once it tries to process them and will always process the most recent request. 

Here is the memory usage graph for CCM before and after fix (after intentionally making CCM to requeue requests to mimic behavior on 429 or 5XX errors):
![Screenshot 2025-03-08 at 2 40 23 PM](https://github.com/user-attachments/assets/0f89c896-3519-4c06-af71-dd2f05dc1bca)

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

