### PR TITLE
[improvement] : add flag to set nodebalancer subnet

### DIFF
--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -39,17 +39,18 @@ var Options struct {
 	EnableRouteController    bool
 	EnableTokenHealthChecker bool
 	// Deprecated: use VPCNames instead
-	VPCName                    string
-	VPCNames                   string
-	SubnetNames                string
-	LoadBalancerType           string
-	BGPNodeSelector            string
-	IpHolderSuffix             string
-	LinodeExternalNetwork      *net.IPNet
-	NodeBalancerTags           []string
-	DefaultNBType              string
-	GlobalStopChannel          chan<- struct{}
-	EnableIPv6ForLoadBalancers bool
+	VPCName                       string
+	VPCNames                      string
+	SubnetNames                   string
+	LoadBalancerType              string
+	BGPNodeSelector               string
+	IpHolderSuffix                string
+	LinodeExternalNetwork         *net.IPNet
+	NodeBalancerTags              []string
+	DefaultNBType                 string
+	NodeBalancerBackendIPv4Subnet string
+	GlobalStopChannel             chan<- struct{}
+	EnableIPv6ForLoadBalancers    bool
 }
 
 type linodeCloud struct {

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -103,6 +103,9 @@ spec:
             {{- if .Values.enableIPv6ForLoadBalancers }}
             - --enable-ipv6-for-loadbalancers={{ .Values.enableIPv6ForLoadBalancers }}
             {{- end }}
+            {{- if .Values.nodeBalancerBackendIPv4Subnet }}
+            - --nodebalancer-backend-ipv4-subnet={{ .Values.nodeBalancerBackendIPv4Subnet }}
+            {{- end }}
           {{- with .Values.containerSecurityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -91,6 +91,9 @@ tolerations:
 # This can also be controlled per-service using the "service.beta.kubernetes.io/linode-loadbalancer-enable-ipv6-ingress" annotation
 # enableIPv6ForLoadBalancers: true
 
+# nodeBalancerBackendIPv4Subnet is the subnet to use for the backend ips of the NodeBalancer
+# nodeBalancerBackendIPv4Subnet: ""
+
 # This section adds the ability to pass environment variables to adjust CCM defaults
 # https://github.com/linode/linode-cloud-controller-manager/blob/master/cloud/linode/loadbalancers.go
 # LINODE_HOSTNAME_ONLY_INGRESS type bool is supported

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -44,6 +44,7 @@ The CCM supports the following flags:
 | `--ip-holder-suffix` | `""` | Suffix to append to the IP holder name when using shared IP fail-over with BGP |
 | `--default-nodebalancer-type` | `common` | Default type of NodeBalancer to create (options: common, premium) |
 | `--nodebalancer-tags` | `[]` | Linode tags to apply to all NodeBalancers |
+| `--nodebalancer-backend-ipv4-subnet` | `""` | ipv4 subnet to use for NodeBalancer backends |
 | `--enable-ipv6-for-loadbalancers` | `false` | Set both IPv4 and IPv6 addresses for all LoadBalancer services (when disabled, only IPv4 is used). This can also be configured per-service using the `service.beta.kubernetes.io/linode-loadbalancer-enable-ipv6-ingress` annotation. |
 
 ## Configuration Methods

--- a/docs/configuration/loadbalancer.md
+++ b/docs/configuration/loadbalancer.md
@@ -197,6 +197,8 @@ metadata:
     service.beta.kubernetes.io/linode-loadbalancer-subnet-name: "subnet1"
 ```
 
+If CCM is started with `--nodebalancer-backend-ipv4-subnet` flag, then it will not allow provisioning of nodebalancer unless subnet specified in service annotation lie within the subnet specified using the flag. This is to prevent accidental overlap between nodebalancer backend ips and pod CIDRs.
+
 ## Advanced Configuration
 
 ### Using Existing NodeBalancers

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func main() {
 	command.Flags().StringVar(&linode.Options.BGPNodeSelector, "bgp-node-selector", "", "node selector to use to perform shared IP fail-over with BGP (e.g. cilium-bgp-peering=true")
 	command.Flags().StringVar(&linode.Options.IpHolderSuffix, "ip-holder-suffix", "", "suffix to append to the ip holder name when using shared IP fail-over with BGP (e.g. ip-holder-suffix=my-cluster-name")
 	command.Flags().StringVar(&linode.Options.DefaultNBType, "default-nodebalancer-type", string(linodego.NBTypeCommon), "default type of NodeBalancer to create (options: common, premium)")
+	command.Flags().StringVar(&linode.Options.NodeBalancerBackendIPv4Subnet, "nodebalancer-backend-ipv4-subnet", "", "ipv4 subnet to use for NodeBalancer backends")
 	command.Flags().StringSliceVar(&linode.Options.NodeBalancerTags, "nodebalancer-tags", []string{}, "Linode tags to apply to all NodeBalancers")
 	command.Flags().BoolVar(&linode.Options.EnableIPv6ForLoadBalancers, "enable-ipv6-for-loadbalancers", false, "set both IPv4 and IPv6 addresses for all LoadBalancer services (when disabled, only IPv4 is used)")
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:
If CCM is started with `--nodebalancer-backend-ipv4-subnet` flag, then it will not allow provisioning of nodebalancer unless subnet specified in service annotation lie within the subnet specified using the flag. This is to prevent accidental overlap between nodebalancer backend ips and pod CIDRs.

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

