### PR TITLE
[fix] : add k8s node cache and prefer providerID for node search

### DIFF
--- a/cloud/linode/node_controller.go
+++ b/cloud/linode/node_controller.go
@@ -137,7 +137,7 @@ func (c *k8sNodeCache) getProviderID(nodeName string) (string, bool) {
 func newK8sNodeCache() *k8sNodeCache {
 	timeout := defaultK8sNodeCacheTTL
 	if raw, ok := os.LookupEnv("K8S_NODECACHE_TTL"); ok {
-		if t, _ := strconv.Atoi(raw); t > 0 {
+		if t, err := strconv.Atoi(raw); t > 0 && err == nil {
 			timeout = time.Duration(t) * time.Second
 		}
 	}

--- a/cloud/linode/node_controller.go
+++ b/cloud/linode/node_controller.go
@@ -74,8 +74,8 @@ func (c *k8sNodeCache) updateCache(kubeclient kubernetes.Interface) {
 		return
 	}
 
-	nodes := make(map[string]*v1.Node, nodeList.Size())
-	providerIDs := make(map[string]string, nodeList.Size())
+	nodes := make(map[string]*v1.Node, len(nodeList.Items))
+	providerIDs := make(map[string]string, len(nodeList.Items))
 	for _, node := range nodeList.Items {
 		if node.Spec.ProviderID == "" {
 			klog.Errorf("Empty providerID [%s] for node %s, skipping it", node.Spec.ProviderID, node.Name)

--- a/cloud/linode/node_controller.go
+++ b/cloud/linode/node_controller.go
@@ -24,9 +24,12 @@ import (
 )
 
 const (
-	informerResyncPeriod = 1 * time.Minute
-	defaultMetadataTTL   = 300 * time.Second
+	informerResyncPeriod   = 1 * time.Minute
+	defaultMetadataTTL     = 300 * time.Second
+	defaultK8sNodeCacheTTL = 300 * time.Second
 )
+
+var registeredK8sNodeCache *k8sNodeCache = newK8sNodeCache()
 
 type nodeRequest struct {
 	node      *v1.Node
@@ -46,6 +49,101 @@ type nodeController struct {
 
 	queue         workqueue.TypedDelayingInterface[nodeRequest]
 	nodeLastAdded map[string]time.Time
+}
+
+type k8sNodeCache struct {
+	sync.RWMutex
+	nodes       map[string]*v1.Node
+	providerIDs map[string]string
+	lastUpdate  time.Time
+	ttl         time.Duration
+}
+
+// updateCache updates the k8s node cache with the latest nodes from the k8s API server.
+func (c *k8sNodeCache) updateCache(kubeclient kubernetes.Interface) {
+	c.Lock()
+	defer c.Unlock()
+	if time.Since(c.lastUpdate) < c.ttl {
+		return
+	}
+
+	nodeList, err := kubeclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		klog.Errorf("failed to list nodes, cannot create/update k8s node cache: %s", err)
+		return
+	}
+
+	nodes := make(map[string]*v1.Node, nodeList.Size())
+	providerIDs := make(map[string]string, nodeList.Size())
+	for _, node := range nodeList.Items {
+		if node.Spec.ProviderID == "" {
+			klog.Errorf("Empty providerID [%s] for node %s, skipping it", node.Spec.ProviderID, node.Name)
+			continue
+		}
+		nodes[node.Name] = &node
+		providerIDs[node.Spec.ProviderID] = node.Name
+	}
+
+	c.nodes = nodes
+	c.providerIDs = providerIDs
+	c.lastUpdate = time.Now()
+}
+
+func (c *k8sNodeCache) addNodeToCache(node *v1.Node) {
+	c.Lock()
+	defer c.Unlock()
+	if node.Spec.ProviderID == "" {
+		klog.Errorf("Empty providerID [%s] for node %s, skipping it", node.Spec.ProviderID, node.Name)
+		return
+	}
+	c.nodes[node.Name] = node
+	c.providerIDs[node.Spec.ProviderID] = node.Name
+}
+
+// getNodeLabel returns the k8s node label for the given provider ID or instance label.
+// If the provider ID or label is not found in the cache, it returns an empty string and false.
+func (c *k8sNodeCache) getNodeLabel(providerID string, instanceLabel string) (string, bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	// check if instance label matches with the registered k8s node
+	if _, exists := c.nodes[instanceLabel]; exists {
+		return instanceLabel, true
+	}
+
+	// check if provider id matches with the registered k8s node
+	if label, exists := c.providerIDs[providerID]; exists {
+		return label, true
+	}
+
+	return "", false
+}
+
+// getProviderID returns linode specific providerID for given k8s node name
+func (c *k8sNodeCache) getProviderID(nodeName string) (string, bool) {
+	c.RLock()
+	defer c.RUnlock()
+
+	if node, exists := c.nodes[nodeName]; exists {
+		return node.Spec.ProviderID, true
+	}
+
+	return "", false
+}
+
+func newK8sNodeCache() *k8sNodeCache {
+	timeout := defaultK8sNodeCacheTTL
+	if raw, ok := os.LookupEnv("K8S_NODECACHE_TTL"); ok {
+		if t, _ := strconv.Atoi(raw); t > 0 {
+			timeout = time.Duration(t) * time.Second
+		}
+	}
+
+	return &k8sNodeCache{
+		nodes:       make(map[string]*v1.Node, 0),
+		providerIDs: make(map[string]string, 0),
+		ttl:         timeout,
+	}
 }
 
 func newNodeController(kubeclient kubernetes.Interface, client client.Client, informer v1informers.NodeInformer, instanceCache *instances) *nodeController {
@@ -145,6 +243,7 @@ func (s *nodeController) processNext() bool {
 		klog.Errorf("failed to add metadata for node (%s); will not retry: %s", request.node.Name, err)
 	}
 
+	registeredK8sNodeCache.updateCache(s.kubeclient)
 	return true
 }
 
@@ -202,6 +301,7 @@ func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
 		return nil
 	}
 
+	var updatedNode *v1.Node
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Get a fresh copy of the node so the resource version is up-to-date
 		nodeResult, err := s.kubeclient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
@@ -223,13 +323,14 @@ func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
 		if nodeResult.Annotations[annotations.AnnLinodeNodePrivateIP] != expectedPrivateIP && expectedPrivateIP != "" {
 			nodeResult.Annotations[annotations.AnnLinodeNodePrivateIP] = expectedPrivateIP
 		}
-		_, err = s.kubeclient.CoreV1().Nodes().Update(ctx, nodeResult, metav1.UpdateOptions{})
+		updatedNode, err = s.kubeclient.CoreV1().Nodes().Update(ctx, nodeResult, metav1.UpdateOptions{})
 		return err
 	}); err != nil {
 		klog.V(1).ErrorS(err, "Node update error")
 		return err
 	}
 
+	registeredK8sNodeCache.addNodeToCache(updatedNode)
 	s.SetLastMetadataUpdate(node.Name)
 
 	return nil

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -12,6 +12,8 @@ The CCM can be configured using environment variables and flags. Environment var
 |----------|---------|-------------|
 | `LINODE_INSTANCE_CACHE_TTL` | `15` | Default timeout of instance cache in seconds |
 | `LINODE_ROUTES_CACHE_TTL_SECONDS` | `60` | Default timeout of route cache in seconds |
+| `LINODE_METADATA_TTL` | `300` | Default linode metadata timeout in seconds |
+| `K8S_NODECACHE_TTL` | `300` | Default timeout of k8s node cache in seconds |
 
 ### API Configuration
 

--- a/e2e/test/route-controller-test/chainsaw-test.yaml
+++ b/e2e/test/route-controller-test/chainsaw-test.yaml
@@ -61,3 +61,72 @@ spec:
             check:
               ($error == null): true
               (contains($stdout, 'Pod CIDR not found in VPC interface configuration')): false
+    - name: Modify instance label using linodeAPI and check if it still has the route configured
+      try:
+        - script:
+            content: |
+              set -e
+
+              # Use last node to change its label
+              node=$(kubectl get nodes -o jsonpath='{.items[-1].metadata.name}')  
+              if [ -z "$node" ]; then
+                  echo "Error: No nodes found in cluster"
+                  exit 1
+              fi
+
+              instance_id=$(kubectl get node "$node" -o jsonpath='{.spec.providerID}' | sed 's/linode:\/\///')
+              pod_cidr=$(kubectl get node "$node" -o jsonpath='{.spec.podCIDR}')
+              newNodeName=${node}-test
+
+              # Change label of linode
+              resp=$(curl -X PUT --write-out "%{http_code}\n" \
+                  --silent --output /dev/null \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4/linode/instances/$instance_id" \
+                  --data "{\"label\": \"$newNodeName\"}")
+
+              if [[ $resp != "200" ]]; then
+                  echo "Failed updating node label"
+                  exit 1
+              fi
+
+              currentLabel=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  "https://api.linode.com/v4/linode/instances/$instance_id" \
+                  | jq -r '.label')
+
+              if [[ $currentLabel == $newNodeName ]]; then
+                  echo "Labels match"
+              fi
+
+              # sleep for a minute for route_controller to reconcile few times
+              sleep 60
+
+              # Get interface details for this config
+              interfaces=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  "https://api.linode.com/v4/linode/instances/$instance_id/configs" \
+                  | jq -r '.data[0].interfaces')
+
+              # Check if pod CIDR still exists in the VPC interface IP ranges
+              if echo "$interfaces" | jq -e --arg cidr "$pod_cidr" '.[] | select(.purpose == "vpc") | .ip_ranges[] | select(. == $cidr)' > /dev/null; then
+                  echo "Pod CIDR found in VPC interface configuration"
+              else
+                  echo "Pod CIDR not found in VPC interface configuration"
+                  echo "Current VPC interface configuration:"
+                  echo "$interfaces" | jq '.[] | select(.purpose == "vpc")'
+              fi
+
+              # revert label to original value
+              curl -X PUT --write-out "%{http_code}\n" \
+                  --silent --output /dev/null \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" \
+                  "https://api.linode.com/v4/linode/instances/$instance_id" \
+                  --data "{\"label\": \"$node\"}"
+            check:
+              ($error == null): true
+              (contains($stdout, 'Failed updating node label')): false
+              (contains($stdout, 'Labels match')): true
+              (contains($stdout, 'Pod CIDR found in VPC interface configuration')): true


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:
This PR makes sure we don't delete routes from ip_ranges if someone accidentally changes linode label. This PR introduces k8s cache which stores node objects and their linode specific providerIDs and uses them when building list of routes or creating routes.
* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

