### PR TITLE
[CI] Add nightly merge workflow for gh-pages

### DIFF
--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -1,0 +1,26 @@
+name: 'Nightly Merge'
+
+on:
+  push:
+    branches:
+        - main
+
+jobs:
+  nightly-merge:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Full clone necessary for proper merge
+
+    - name: Merge main into gh-pages 
+      uses: robotology/gh-action-nightly-merge@v1.5.2
+      with:
+        stable_branch: 'master'
+        development_branch: 'devel'
+        allow_ff: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-merge.yml
+++ b/.github/workflows/nightly-merge.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Merge main into gh-pages 
       uses: robotology/gh-action-nightly-merge@v1.5.2
       with:
-        stable_branch: 'master'
-        development_branch: 'devel'
+        stable_branch: 'main'
+        development_branch: 'gh-pages'
         allow_ff: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### General:
This PR adds the nightly merge workflow to the CI pipeline to automatically merge changes to main into the gh-pages branch. This is to prevent documentation from becoming out of date and to avoid needing to manually merge changes.

* [X] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [X] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [X] Are you addressing a single feature in this PR? 
1. [X] Are your commits atomic, addressing one change per commit?
1. [X] Are you following the conventions of the language? 
1. [X] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [X] Have you explained your rationale for why this feature is needed?

