### PR TITLE
[fix] Ignore ipv6 routes

### DIFF
--- a/cloud/linode/route_controller_test.go
+++ b/cloud/linode/route_controller_test.go
@@ -381,6 +381,40 @@ func TestCreateRoute(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	v6Route := &cloudprovider.Route{
+		Name:            "route2",
+		TargetNode:      types.NodeName(name),
+		DestinationCIDR: "fd00::/64",
+	}
+	t.Run("should return no error if given a route with an IPv6 address", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mocks.NewMockClient(ctrl)
+		instanceCache := newInstances(client)
+		routeController, err := newRoutes(client, instanceCache)
+		require.NoError(t, err)
+
+		err = routeController.CreateRoute(ctx, "dummy", "dummy", v6Route)
+		assert.NoError(t, err)
+	})
+
+	badV6Route := &cloudprovider.Route{
+		Name:            "route2",
+		TargetNode:      types.NodeName(name),
+		DestinationCIDR: ":/64",
+	}
+	t.Run("should return error if IP address is not v4 or v6", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mocks.NewMockClient(ctrl)
+		instanceCache := newInstances(client)
+		routeController, err := newRoutes(client, instanceCache)
+		require.NoError(t, err)
+
+		err = routeController.CreateRoute(ctx, "dummy", "dummy", badV6Route)
+		assert.Error(t, err)
+	})
+
 	addressRange1 := "10.10.10.0/24"
 	routesInVPC := []linodego.VPCIP{
 		{


### PR DESCRIPTION
### General:
Currently, route_controller will attempt to create routes for IPv6 pod CIDRs and will fail, which means it will retry indefinitely (see logs below). IPv6 routes don't need to be configured because of the huge address space available, so this PR updates CCM route_controller to effectively ignore IPv6 CIDRs. This is done by adding the route to a local cache of "configured" routes, then appending those routes to the list of configured routes returned by ListRoutes. This tells route_controller that the route has been configured, but no configuration has actually been made.
```
I0402 16:24:49.847301       1 route_controller.go:214] action for Node "ccm-717a8f3-md-0-qzzm2-nx6vj" with CIDR "10.192.2.0/24": "keep"
I0402 16:24:49.847305       1 route_controller.go:214] action for Node "ccm-717a8f3-md-0-qzzm2-nx6vj" with CIDR "fd00::/64": "add"
I0402 16:24:49.847316       1 route_controller.go:288] route spec to be created: &{ ccm-717a8f3-md-0-qzzm2-nx6vj false [{Hostname ccm-717a8f3-md-0-qzzm2-nx6vj} {InternalIP 10.0.0.4} {InternalIP 192.168.148.132} {ExternalIP 172.233.184.144} {ExternalIP 2a01:7e04::f03c:95ff:fe07:d941}] fd00::/64 false}
I0402 16:24:49.847411       1 route_controller.go:302] Creating route for node ccm-717a8f3-md-0-qzzm2-nx6vj fd00::/64 with hint b6231493-7793-408c-b7a6-cb9d4fe558f3, throttled 54.65µs
E0402 16:24:50.009509       1 route_controller.go:327] Could not create route b6231493-7793-408c-b7a6-cb9d4fe558f3 fd00::/64 for node ccm-717a8f3-md-0-qzzm2-nx6vj: [400] [ip_ranges[1]] Only IPv4 ranges are allowed
I0402 16:24:50.009615       1 route_controller.go:376] set node ccm-717a8f3-control-plane-nstww with NodeNetworkUnavailable=false was canceled because it is already set
I0402 16:24:50.009544       1 route_controller.go:385] Patching node status ccm-717a8f3-md-0-qzzm2-nx6vj with false previous condition was:&NodeCondition{Type:NetworkUnavailable,Status:False,LastHeartbeatTime:2025-04-02 16:24:39 +0000 UTC,LastTransitionTime:2025-04-02 16:24:39 +0000 UTC,Reason:CiliumIsUp,Message:Cilium is running on this node,}
I0402 16:24:50.010696       1 event.go:389] "Event occurred" object="ccm-717a8f3-md-0-qzzm2-nx6vj" fieldPath="" kind="Node" apiVersion="" type="Warning" reason="FailedToCreateRoute" message="Could not create route b6231493-7793-408c-b7a6-cb9d4fe558f3 fd00::/64 for node ccm-717a8f3-md-0-qzzm2-nx6vj after 162.019903ms: [400] [ip_ranges[1]] Only IPv4 ranges are allowed"
```
After implementing the change, we see that the IPv6 route gets "configured", and route_controller no longer tries to configure it indefinitely.
```
I0403 20:14:55.698515       1 route_controller.go:214] action for Node "ccm-717a8f3-control-plane-nstww" with CIDR "10.192.0.0/24": "keep"
I0403 20:14:55.698540       1 route_controller.go:214] action for Node "ccm-717a8f3-md-0-qzzm2-mwkb5" with CIDR "10.192.1.0/24": "keep"
I0403 20:14:55.698546       1 route_controller.go:214] action for Node "ccm-717a8f3-md-0-qzzm2-nx6vj" with CIDR "10.192.2.0/24": "keep"
I0403 20:14:55.698550       1 route_controller.go:214] action for Node "ccm-717a8f3-md-0-qzzm2-nx6vj" with CIDR "fd00::/64": "add"
I0403 20:14:55.698562       1 route_controller.go:288] route spec to be created: &{ ccm-717a8f3-md-0-qzzm2-nx6vj false [{Hostname ccm-717a8f3-md-0-qzzm2-nx6vj} {InternalIP 10.0.0.4} {InternalIP 192.168.148.132} {ExternalIP 172.233.184.144} {ExternalIP 2a01:7e04::f03c:95ff:fe07:d941}] fd00::/64 false}
I0403 20:14:55.698589       1 route_controller.go:302] Creating route for node ccm-717a8f3-md-0-qzzm2-nx6vj fd00::/64 with hint b6231493-7793-408c-b7a6-cb9d4fe558f3, throttled 260ns
I0403 20:14:55.698688       1 route_controller.go:323] Created route for node ccm-717a8f3-md-0-qzzm2-nx6vj fd00::/64 with hint b6231493-7793-408c-b7a6-cb9d4fe558f3 after 88.74µs
I0403 20:14:55.698842       1 route_controller.go:376] set node ccm-717a8f3-md-0-qzzm2-nx6vj with NodeNetworkUnavailable=false was canceled because it is already set
I0403 20:14:55.698855       1 route_controller.go:376] set node ccm-717a8f3-control-plane-nstww with NodeNetworkUnavailable=false was canceled because it is already set
I0403 20:14:55.698878       1 route_controller.go:376] set node ccm-717a8f3-md-0-qzzm2-mwkb5 with NodeNetworkUnavailable=false was canceled because it is already set
I0403 20:14:57.797698       1 node_controller.go:194] NodeController will handle newly updated node (ccm-717a8f3-control-plane-nstww) metadata
I0403 20:14:57.797761       1 node_controller.go:270] "NodeController handling node metadata" node="ccm-717a8f3-control-plane-nstww"
I0403 20:14:57.797996       1 node_controller.go:280] "Skipping refresh, ttl not reached" node="ccm-717a8f3-control-plane-nstww" ttl="5m0s" metadata_age="2.291260097s"
I0403 20:15:04.833740       1 route_controller.go:214] action for Node "ccm-717a8f3-md-0-qzzm2-mwkb5" with CIDR "10.192.1.0/24": "keep"
I0403 20:15:04.833775       1 route_controller.go:214] action for Node "ccm-717a8f3-md-0-qzzm2-nx6vj" with CIDR "10.192.2.0/24": "keep"
I0403 20:15:04.833780       1 route_controller.go:214] action for Node "ccm-717a8f3-md-0-qzzm2-nx6vj" with CIDR "fd00::/64": "keep"
I0403 20:15:04.833785       1 route_controller.go:214] action for Node "ccm-717a8f3-control-plane-nstww" with CIDR "10.192.0.0/24": "keep"
I0403 20:15:04.833834       1 route_controller.go:376] set node ccm-717a8f3-control-plane-nstww with NodeNetworkUnavailable=false was canceled because it is already set
I0403 20:15:04.833844       1 route_controller.go:376] set node ccm-717a8f3-md-0-qzzm2-mwkb5 with NodeNetworkUnavailable=false was canceled because it is already set
I0403 20:15:04.833851       1 route_controller.go:376] set node ccm-717a8f3-md-0-qzzm2-nx6vj with NodeNetworkUnavailable=false was canceled because it is already set
```

* [X] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [X] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [X] Does your submission pass tests?
1. [X] Have you added tests? 
1. [X] Are you addressing a single feature in this PR? 
1. [X] Are your commits atomic, addressing one change per commit?
1. [X] Are you following the conventions of the language? 
1. [X] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [X] Have you explained your rationale for why this feature is needed? 
