### PR TITLE
[improvement] Refactor code blocks ignored by errorlint

### DIFF
--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -628,8 +628,8 @@ func (l *loadbalancers) getNodeBalancerByIPv4(ctx context.Context, service *v1.S
 func (l *loadbalancers) getNodeBalancerByID(ctx context.Context, service *v1.Service, id int) (*linodego.NodeBalancer, error) {
 	nb, err := l.client.GetNodeBalancer(ctx, id)
 	if err != nil {
-		//nolint: errorlint //need type assertion for code field to work
-		if apiErr, ok := err.(*linodego.Error); ok && apiErr.Code == http.StatusNotFound {
+		var targetError *linodego.Error
+		if errors.As(err, &targetError) && targetError.Code == http.StatusNotFound {
 			return nil, lbNotFoundError{serviceNn: getServiceNn(service), nodeBalancerID: id}
 		}
 		return nil, err

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -126,15 +126,13 @@ func (l *loadbalancers) cleanupOldNodeBalancer(ctx context.Context, service *v1.
 	}
 
 	previousNB, err := l.getNodeBalancerByStatus(ctx, service)
-	//nolint: errorlint //conversion to errors.Is() may break chainsaw tests
-	switch err.(type) {
-	case nil:
-		// continue execution
-		break
-	case lbNotFoundError:
-		return nil
-	default:
-		return err
+	if err != nil {
+		var targetError *lbNotFoundError
+		if errors.As(err, &targetError) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	nb, err := l.getNodeBalancerForService(ctx, service)
@@ -178,17 +176,14 @@ func (l *loadbalancers) GetLoadBalancer(ctx context.Context, clusterName string,
 	}
 
 	nb, err := l.getNodeBalancerForService(ctx, service)
-	//nolint: errorlint //conversion to errors.Is() may break chainsaw tests
-	switch err.(type) {
-	case nil:
-		break
-
-	case lbNotFoundError:
-		return nil, false, nil
-
-	default:
-		sentry.CaptureError(ctx, err)
-		return nil, false, err
+	if err != nil {
+		var targetError *lbNotFoundError
+		if errors.As(err, &targetError) {
+			return nil, false, nil
+		} else {
+			sentry.CaptureError(ctx, err)
+			return nil, false, err
+		}
 	}
 
 	return makeLoadBalancerStatus(service, nb), true, nil
@@ -257,31 +252,30 @@ func (l *loadbalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 	var nb *linodego.NodeBalancer
 
 	nb, err = l.getNodeBalancerForService(ctx, service)
-	//nolint: errorlint //conversion to errors.Is() may break chainsaw tests
-	switch err.(type) {
-	case lbNotFoundError:
-		if service.GetAnnotations()[annotations.AnnLinodeNodeBalancerID] != "" {
-			// a load balancer annotation has been created so a NodeBalancer is coming, error out and retry later
-			klog.Infof("NodeBalancer created but not available yet, waiting...")
-			sentry.CaptureError(ctx, err)
-			return nil, err
-		}
-
-		if nb, err = l.buildLoadBalancerRequest(ctx, clusterName, service, nodes); err != nil {
-			sentry.CaptureError(ctx, err)
-			return nil, err
-		}
-		klog.Infof("created new NodeBalancer (%d) for service (%s)", nb.ID, serviceNn)
-
-	case nil:
+	if err == nil {
 		if err = l.updateNodeBalancer(ctx, clusterName, service, nodes, nb); err != nil {
 			sentry.CaptureError(ctx, err)
 			return nil, err
 		}
+	} else {
+		var targetError *lbNotFoundError
+		if errors.As(err, &targetError) {
+			if service.GetAnnotations()[annotations.AnnLinodeNodeBalancerID] != "" {
+				// a load balancer annotation has been created so a NodeBalancer is coming, error out and retry later
+				klog.Infof("NodeBalancer created but not available yet, waiting...")
+				sentry.CaptureError(ctx, err)
+				return nil, err
+			}
 
-	default:
-		sentry.CaptureError(ctx, err)
-		return nil, err
+			if nb, err = l.buildLoadBalancerRequest(ctx, clusterName, service, nodes); err != nil {
+				sentry.CaptureError(ctx, err)
+				return nil, err
+			}
+			klog.Infof("created new NodeBalancer (%d) for service (%s)", nb.ID, serviceNn)
+		} else {
+			sentry.CaptureError(ctx, err)
+			return nil, err
+		}
 	}
 
 	klog.Infof("NodeBalancer (%d) has been ensured for service (%s)", nb.ID, serviceNn)
@@ -558,19 +552,16 @@ func (l *loadbalancers) EnsureLoadBalancerDeleted(ctx context.Context, clusterNa
 	}
 
 	nb, err := l.getNodeBalancerForService(ctx, service)
-	//nolint: errorlint //conversion to errors.Is() may break chainsaw tests
-	switch getErr := err.(type) {
-	case nil:
-		break
-
-	case lbNotFoundError:
-		klog.Infof("short-circuiting deletion for NodeBalancer for service (%s) as one does not exist: %s", serviceNn, err)
-		return nil
-
-	default:
-		klog.Errorf("failed to get NodeBalancer for service (%s): %s", serviceNn, err)
-		sentry.CaptureError(ctx, getErr)
-		return err
+	if err != nil {
+		var targetError *lbNotFoundError
+		if errors.As(err, &targetError) {
+			klog.Infof("short-circuiting deletion for NodeBalancer for service (%s) as one does not exist: %s", serviceNn, err)
+			return nil
+		} else {
+			klog.Errorf("failed to get NodeBalancer for service (%s): %s", serviceNn, err)
+			sentry.CaptureError(ctx, err)
+			return err
+		}
 	}
 
 	if l.shouldPreserveNodeBalancer(service) {

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -553,7 +553,7 @@ func (l *loadbalancers) EnsureLoadBalancerDeleted(ctx context.Context, clusterNa
 
 	nb, err := l.getNodeBalancerForService(ctx, service)
 	if err != nil {
-		var targetError *lbNotFoundError
+		var targetError lbNotFoundError
 		if errors.As(err, &targetError) {
 			klog.Infof("short-circuiting deletion for NodeBalancer for service (%s) as one does not exist: %s", serviceNn, err)
 			return nil

--- a/cloud/linode/node_controller.go
+++ b/cloud/linode/node_controller.go
@@ -236,12 +236,14 @@ func (s *nodeController) processNext() bool {
 		return true
 	}
 	err := s.handleNode(context.TODO(), request.node)
-	var targetError *linodego.Error
 	if err != nil {
+		var targetError *linodego.Error
 		if errors.As(err, &targetError) &&
 			(targetError.Code >= http.StatusInternalServerError || targetError.Code == http.StatusTooManyRequests) {
 			klog.Errorf("failed to add metadata for node (%s); retrying in 1 minute: %s", request.node.Name, err)
 			s.queue.AddAfter(request, retryInterval)
+		} else {
+			klog.Errorf("failed to add metadata for node (%s); will not retry: %s", request.node.Name, err)
 		}
 	}
 


### PR DESCRIPTION
### General:
As mentioned in [PR 349](https://github.com/linode/linode-cloud-controller-manager/pull/349), several errorlint errors were ignored because attempting to fix them resulted in two chainsaw tests breaking. This PR resolves the errorlint errors so we avoid issues with wrapped errors.

* [X] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [X] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [X] Does your submission pass tests?
1. [X] Are you addressing a single feature in this PR? 
1. [X] Are your commits atomic, addressing one change per commit?
1. [X] Are you following the conventions of the language? 
1. [X] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [X] Have you explained your rationale for why this feature is needed? 

