### PR TITLE
[fix] : use updated service status as upstream controller can pass wrong info

### DIFF
--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -160,7 +160,14 @@ func (l *loadbalancers) getLatestServiceLoadBalancerStatus(ctx context.Context, 
 // getNodeBalancerByStatus attempts to get the NodeBalancer from the IP or hostname specified in the
 // most recent LoadBalancer status.
 func (l *loadbalancers) getNodeBalancerByStatus(ctx context.Context, service *v1.Service) (nb *linodego.NodeBalancer, err error) {
-	for _, ingress := range service.Status.LoadBalancer.Ingress {
+	lb := service.Status.LoadBalancer
+	updatedLb, err := l.getLatestServiceLoadBalancerStatus(ctx, service)
+	if err != nil {
+		klog.V(3).Infof("failed to get latest LoadBalancer status for service (%s): %v", getServiceNn(service), err)
+	} else {
+		lb = updatedLb
+	}
+	for _, ingress := range lb.Ingress {
 		if ingress.IP != "" {
 			address, err := netip.ParseAddr(ingress.IP)
 			if err != nil {
@@ -467,14 +474,19 @@ func (l *loadbalancers) updateNodeBalancer(
 				klog.Infof("Node %s is excluded from NodeBalancer by annotation, skipping", node.Name)
 				continue
 			}
-			newNodeOpts := l.buildNodeBalancerNodeConfigRebuildOptions(node, port.NodePort, subnetID, newNBCfg.Protocol)
+			var newNodeOpts *linodego.NodeBalancerConfigRebuildNodeOptions
+			newNodeOpts, err = l.buildNodeBalancerNodeConfigRebuildOptions(node, port.NodePort, subnetID, newNBCfg.Protocol)
+			if err != nil {
+				sentry.CaptureError(ctx, err)
+				return fmt.Errorf("failed to build NodeBalancer node config options for node %s: %w", node.Name, err)
+			}
 			oldNodeID, ok := oldNBNodeIDs[newNodeOpts.Address]
 			if ok {
 				newNodeOpts.ID = oldNodeID
 			} else {
 				klog.Infof("No preexisting node id for %v found.", newNodeOpts.Address)
 			}
-			newNBNodes = append(newNBNodes, newNodeOpts)
+			newNBNodes = append(newNBNodes, *newNodeOpts)
 		}
 		// If there's no existing config, create it
 		var rebuildOpts linodego.NodeBalancerConfigRebuildOptions
@@ -1033,12 +1045,17 @@ func (l *loadbalancers) buildLoadBalancerRequest(ctx context.Context, clusterNam
 		}
 		createOpt := config.GetCreateOptions()
 
-		for _, n := range nodes {
-			if _, ok := n.Annotations[annotations.AnnExcludeNodeFromNb]; ok {
-				klog.Infof("Node %s is excluded from NodeBalancer by annotation, skipping", n.Name)
+		for _, node := range nodes {
+			if _, ok := node.Annotations[annotations.AnnExcludeNodeFromNb]; ok {
+				klog.Infof("Node %s is excluded from NodeBalancer by annotation, skipping", node.Name)
 				continue
 			}
-			createOpt.Nodes = append(createOpt.Nodes, l.buildNodeBalancerNodeConfigRebuildOptions(n, port.NodePort, subnetID, config.Protocol).NodeBalancerNodeCreateOptions)
+			newNodeOpts, err := l.buildNodeBalancerNodeConfigRebuildOptions(node, port.NodePort, subnetID, config.Protocol)
+			if err != nil {
+				sentry.CaptureError(ctx, err)
+				return nil, fmt.Errorf("failed to build NodeBalancer node config options for node %s: %w", node.Name, err)
+			}
+			createOpt.Nodes = append(createOpt.Nodes, newNodeOpts.NodeBalancerNodeCreateOptions)
 		}
 
 		configs = append(configs, &createOpt)
@@ -1058,10 +1075,14 @@ func coerceString(str string, minLen, maxLen int, padding string) string {
 	return str
 }
 
-func (l *loadbalancers) buildNodeBalancerNodeConfigRebuildOptions(node *v1.Node, nodePort int32, subnetID int, protocol linodego.ConfigProtocol) linodego.NodeBalancerConfigRebuildNodeOptions {
-	nodeOptions := linodego.NodeBalancerConfigRebuildNodeOptions{
+func (l *loadbalancers) buildNodeBalancerNodeConfigRebuildOptions(node *v1.Node, nodePort int32, subnetID int, protocol linodego.ConfigProtocol) (*linodego.NodeBalancerConfigRebuildNodeOptions, error) {
+	nodeIP := getNodePrivateIP(node, subnetID)
+	if nodeIP == "" {
+		return nil, fmt.Errorf("node %s does not have a private IP address", node.Name)
+	}
+	nodeOptions := &linodego.NodeBalancerConfigRebuildNodeOptions{
 		NodeBalancerNodeCreateOptions: linodego.NodeBalancerNodeCreateOptions{
-			Address: fmt.Sprintf("%v:%v", getNodePrivateIP(node, subnetID), nodePort),
+			Address: fmt.Sprintf("%v:%v", nodeIP, nodePort),
 			// NodeBalancer backends must be 3-32 chars in length
 			// If < 3 chars, pad node name with "node-" prefix
 			Label:  coerceString(node.Name, 3, 32, "node-"),
@@ -1075,7 +1096,7 @@ func (l *loadbalancers) buildNodeBalancerNodeConfigRebuildOptions(node *v1.Node,
 	if subnetID != 0 {
 		nodeOptions.SubnetID = subnetID
 	}
-	return nodeOptions
+	return nodeOptions, nil
 }
 
 func (l *loadbalancers) retrieveKubeClient() error {
@@ -1217,6 +1238,9 @@ func getNodePrivateIP(node *v1.Node, subnetID int) string {
 			return addr.Address
 		}
 	}
+
+	// If no internal IP is found, return an empty string.
+	klog.Warningf("No internal IP found for node %s, using empty string as backend IP", node.Name)
 	return ""
 }
 

--- a/cloud/linode/loadbalancers_test.go
+++ b/cloud/linode/loadbalancers_test.go
@@ -3913,7 +3913,7 @@ func Test_getNodePrivateIP(t *testing.T) {
 
 	for _, test := range testcases {
 		t.Run(test.name, func(t *testing.T) {
-			ip := getNodePrivateIP(test.node, test.subnetID)
+			ip, _ := getNodePrivateIP(test.node, test.subnetID)
 			if ip != test.address {
 				t.Error("unexpected certificate")
 				t.Logf("expected: %q", test.address)

--- a/e2e/test/lb-with-node-addition/chainsaw-test.yaml
+++ b/e2e/test/lb-with-node-addition/chainsaw-test.yaml
@@ -52,7 +52,7 @@ spec:
                       echo "Failed fetching nodebalancer config for port 80"
                   fi
 
-                  port_80_up_nodes=$(echo $nbconfig | jq '(.nodes_status.up)|tonumber == 2')
+                  port_80_up_nodes=$(echo $nbconfig | jq '(.nodes_status.up)|tonumber >= 2')
 
                   if [[ $port_80_up_nodes == "true" ]]; then
                       echo "all nodes up"
@@ -92,7 +92,7 @@ spec:
                   if [[ -z $nbconfig ]]; then
                       echo "Failed fetching nodebalancer config for port 80"
                   else
-                      port_80_up_nodes=$(echo $nbconfig | jq '(.nodes_status.up)|tonumber == 3')
+                      port_80_up_nodes=$(echo $nbconfig | jq '(.nodes_status.up)|tonumber >= 3')
 
                       if [[ $port_80_up_nodes == "true" ]]; then
                           echo "all nodes up"


### PR DESCRIPTION
Upstream controller keeps a [serviceCache](https://github.com/kubernetes/cloud-provider/blob/v0.33.2/controllers/service/controller.go#L83) which never gets updated when the service is updated.

When a service is created for the first time, it doesn't have any status field set. It gets stored in the serviceCache of upstream controller. Upon any update to service, this service object gets passed to functions implemented by individual cloud providers (CCM in our case). If there is any error during update, it returns an error and then calls [GetLoadBalancer](https://github.com/kubernetes/cloud-provider/blob/v0.33.2/controllers/service/controller.go#L851) and passes service object to it. In our implementation of [GetLoadBalancer](https://github.com/linode/linode-cloud-controller-manager/blob/v0.8.2/cloud/linode/loadbalancers.go#L229), we rely on the passed service object. It gets passed to [getNodeBalancerByStatus](https://github.com/linode/linode-cloud-controller-manager/blob/v0.8.2/cloud/linode/loadbalancers.go#L162) to iterate over the status and find nodebalancer ip or ingress configured there. However, upstream controller sends service object which doesn't have status set and hence we return saying NodeBalancer doesn't exist to upstream controller. This results into getting into the [else part](https://github.com/kubernetes/cloud-provider/blob/v0.33.2/controllers/service/controller.go#L854) and ignoring the previous error which was returned.

If CCM restarts in-between after the service is created, upstream controller re-populates its cache and now has the status set in service object as that service has NodeBalancer assigned to it. Hence, on subsequent failures during update, its able to detect that LoadBalancer exists and hence continues to retry and eventually succeed when things get sorted out correctly.

This PR fixes:
1. Uses the updated status during GetLoadBalancer call and hence is able to handle error cases.
2. Doesn't pass malformed nodebalancer rebuild requests to linode API and errors out early if ip-address is not present.
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

