### PR TITLE
[feat]: Add custom prefix for load balancer

### DIFF
--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -72,7 +72,7 @@ type linodeCloud struct {
 var (
 	instanceCache     *instances
 	ipHolderCharLimit int = 23
-	LoadBalancerPrefixCharLimit int = 20
+	LoadBalancerPrefixCharLimit int = 19
 )
 
 func init() {

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -58,7 +58,7 @@ var Options struct {
 	ClusterCIDRIPv4                   string
 	NodeCIDRMaskSizeIPv4              int
 	NodeCIDRMaskSizeIPv6              int
-	LoadBalancerPrefix                string
+	NodeBalancerPrefix                string
 }
 
 type linodeCloud struct {
@@ -72,7 +72,7 @@ type linodeCloud struct {
 var (
 	instanceCache     *instances
 	ipHolderCharLimit int = 23
-	LoadBalancerPrefixCharLimit int = 19
+	NodeBalancerPrefixCharLimit int = 19
 )
 
 func init() {
@@ -195,8 +195,8 @@ func newCloud() (cloudprovider.Interface, error) {
 		return nil, fmt.Errorf("%s", msg)
 	}
 
-	if len(Options.LoadBalancerPrefix) > LoadBalancerPrefixCharLimit { 
-		msg := fmt.Sprintf("load-balancer-prefix must be %d characters or less: %s is %d characters\n", LoadBalancerPrefixCharLimit, Options.LoadBalancerPrefix, len(Options.LoadBalancerPrefix))
+	if len(Options.NodeBalancerPrefix) > NodeBalancerPrefixCharLimit { 
+		msg := fmt.Sprintf("nodebalancer-prefix must be %d characters or less: %s is %d characters\n", NodeBalancerPrefixCharLimit, Options.NodeBalancerPrefix, len(Options.NodeBalancerPrefix))
 		klog.Error(msg)
 		return nil, fmt.Errorf("%s", msg)
 	}

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -70,8 +70,8 @@ type linodeCloud struct {
 }
 
 var (
-	instanceCache     *instances
-	ipHolderCharLimit int = 23
+	instanceCache               *instances
+	ipHolderCharLimit           int = 23
 	NodeBalancerPrefixCharLimit int = 19
 )
 
@@ -195,7 +195,7 @@ func newCloud() (cloudprovider.Interface, error) {
 		return nil, fmt.Errorf("%s", msg)
 	}
 
-	if len(Options.NodeBalancerPrefix) > NodeBalancerPrefixCharLimit { 
+	if len(Options.NodeBalancerPrefix) > NodeBalancerPrefixCharLimit {
 		msg := fmt.Sprintf("nodebalancer-prefix must be %d characters or less: %s is %d characters\n", NodeBalancerPrefixCharLimit, Options.NodeBalancerPrefix, len(Options.NodeBalancerPrefix))
 		klog.Error(msg)
 		return nil, fmt.Errorf("%s", msg)

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -58,6 +58,7 @@ var Options struct {
 	ClusterCIDRIPv4                   string
 	NodeCIDRMaskSizeIPv4              int
 	NodeCIDRMaskSizeIPv6              int
+	LoadBalancerPrefix                string
 }
 
 type linodeCloud struct {

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"time"
+	"regexp"
 
 	"github.com/spf13/pflag"
 	"golang.org/x/exp/slices"
@@ -201,8 +202,9 @@ func newCloud() (cloudprovider.Interface, error) {
 		return nil, fmt.Errorf("%s", msg)
 	}
 
-	if len(Options.NodeBalancerPrefix) == 0 {
-		msg := "nodebalancer-prefix cannot be empty string"
+	validPrefix := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	if !validPrefix.MatchString(Options.NodeBalancerPrefix) {
+		msg := fmt.Sprintf("nodebalancer-prefix must be no empty and use only letters, numbers, underscores, and dashes: %s\n", Options.NodeBalancerPrefix)
 		klog.Error(msg)
 		return nil, fmt.Errorf("%s", msg)
 	}

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -72,6 +72,7 @@ type linodeCloud struct {
 var (
 	instanceCache     *instances
 	ipHolderCharLimit int = 23
+	LoadBalancerPrefixCharLimit int = 20
 )
 
 func init() {
@@ -190,6 +191,12 @@ func newCloud() (cloudprovider.Interface, error) {
 
 	if len(Options.IpHolderSuffix) > ipHolderCharLimit {
 		msg := fmt.Sprintf("ip-holder-suffix must be %d characters or less: %s is %d characters\n", ipHolderCharLimit, Options.IpHolderSuffix, len(Options.IpHolderSuffix))
+		klog.Error(msg)
+		return nil, fmt.Errorf("%s", msg)
+	}
+
+	if len(Options.LoadBalancerPrefix) > LoadBalancerPrefixCharLimit { 
+		msg := fmt.Sprintf("load-balancer-prefix must be %d characters or less: %s is %d characters\n", LoadBalancerPrefixCharLimit, Options.LoadBalancerPrefix, len(Options.LoadBalancerPrefix))
 		klog.Error(msg)
 		return nil, fmt.Errorf("%s", msg)
 	}

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -201,6 +201,12 @@ func newCloud() (cloudprovider.Interface, error) {
 		return nil, fmt.Errorf("%s", msg)
 	}
 
+	if len(Options.NodeBalancerPrefix) == 0 {
+		msg := "nodebalancer-prefix cannot be empty string"
+		klog.Error(msg)
+		return nil, fmt.Errorf("%s", msg)
+	}
+
 	// create struct that satisfies cloudprovider.Interface
 	lcloud := &linodeCloud{
 		client:                   linodeClient,

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -127,14 +127,14 @@ func TestNewCloud(t *testing.T) {
 		assert.Error(t, err, "expected error if ipholdersuffix is longer than 23 chars")
 	})
 
-	t.Run("should fail if load-balancer-prefix is longer than 20 chars", func(t *testing.T) {
+	t.Run("should fail if load-balancer-prefix is longer than 19 chars", func(t *testing.T) {
 		prefix := Options.LoadBalancerPrefix
 		Options.LoadBalancerPrefix = strings.Repeat("a", 21)
 		defer func() {
 			Options.LoadBalancerPrefix = prefix
 		}()
 		_, err := newCloud()
-		assert.Error(t, err, "expected error if load-balancer-prefix is longer than 20 chars")
+		assert.Error(t, err, "expected error if load-balancer-prefix is longer than 19 chars")
 	})
 }
 

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -126,6 +126,16 @@ func TestNewCloud(t *testing.T) {
 		_, err := newCloud()
 		assert.Error(t, err, "expected error if ipholdersuffix is longer than 23 chars")
 	})
+
+	t.Run("should fail if load-balancer-prefix is longer than 20 chars", func(t *testing.T) {
+		prefix := Options.LoadBalancerPrefix
+		Options.LoadBalancerPrefix = strings.Repeat("a", 21)
+		defer func() {
+			Options.LoadBalancerPrefix = prefix
+		}()
+		_, err := newCloud()
+		assert.Error(t, err, "expected error if load-balancer-prefix is longer than 20 chars")
+	})
 }
 
 func Test_linodeCloud_LoadBalancer(t *testing.T) {

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -127,14 +127,14 @@ func TestNewCloud(t *testing.T) {
 		assert.Error(t, err, "expected error if ipholdersuffix is longer than 23 chars")
 	})
 
-	t.Run("should fail if load-balancer-prefix is longer than 19 chars", func(t *testing.T) {
-		prefix := Options.LoadBalancerPrefix
-		Options.LoadBalancerPrefix = strings.Repeat("a", 21)
+	t.Run("should fail if nodebalancer-prefix is longer than 19 chars", func(t *testing.T) {
+		prefix := Options.NodeBalancerPrefix
+		Options.NodeBalancerPrefix = strings.Repeat("a", 21)
 		defer func() {
-			Options.LoadBalancerPrefix = prefix
+			Options.NodeBalancerPrefix = prefix
 		}()
 		_, err := newCloud()
-		assert.Error(t, err, "expected error if load-balancer-prefix is longer than 19 chars")
+		assert.Error(t, err, "expected error if nodebalancer-prefix is longer than 19 chars")
 	})
 }
 

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -129,12 +129,32 @@ func TestNewCloud(t *testing.T) {
 
 	t.Run("should fail if nodebalancer-prefix is longer than 19 chars", func(t *testing.T) {
 		prefix := Options.NodeBalancerPrefix
+		rtEnabled := Options.EnableRouteController
+		Options.EnableRouteController = false
+		Options.LoadBalancerType = "nodebalancer"
+		Options.VPCNames = "vpc-test1,vpc-test2"
+		Options.NodeBalancerBackendIPv4SubnetName = "t1"
+		vpcIDs = map[string]int{"vpc-test1": 1, "vpc-test2": 2, "vpc-test3": 3}
+		subnetIDs = map[string]int{"t1": 1, "t2": 2, "t3": 3}
 		Options.NodeBalancerPrefix = strings.Repeat("a", 21)
 		defer func() {
 			Options.NodeBalancerPrefix = prefix
+			Options.LoadBalancerType = ""
+			Options.EnableRouteController = rtEnabled
+			Options.VPCNames = ""
+			Options.NodeBalancerBackendIPv4SubnetID = 0
+			Options.NodeBalancerBackendIPv4SubnetName = ""
+			vpcIDs = map[string]int{}
+			subnetIDs = map[string]int{}
 		}()
 		_, err := newCloud()
-		assert.Error(t, err, "expected error if nodebalancer-prefix is longer than 19 chars")
+		t.Log(err)
+		if !assert.Error(t, err, "expected error if nodebalancer-prefix is longer than 19 chars") {
+			t.Errorf("No error when nodebalancer-prefix is longer 19 than")
+		}
+		if !assert.ErrorContains(t, err, "nodebalancer-prefix") {
+			t.Errorf("Error message does not concern nodebalancer-prefix: %s", err)
+		}
 	})
 }
 

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -152,6 +152,32 @@ func TestNewCloud(t *testing.T) {
 		require.Error(t, err, "expected error if nodebalancer-prefix is longer than 19 chars")
 		require.ErrorContains(t, err, "nodebalancer-prefix")
 	})
+
+	t.Run("should fail if nodebalancer-prefix is empty", func(t *testing.T) {
+		prefix := Options.NodeBalancerPrefix
+		rtEnabled := Options.EnableRouteController
+		Options.EnableRouteController = false
+		Options.LoadBalancerType = "nodebalancer"
+		Options.VPCNames = "vpc-test1,vpc-test2"
+		Options.NodeBalancerBackendIPv4SubnetName = "t1"
+		vpcIDs = map[string]int{"vpc-test1": 1, "vpc-test2": 2, "vpc-test3": 3}
+		subnetIDs = map[string]int{"t1": 1, "t2": 2, "t3": 3}
+		Options.NodeBalancerPrefix = strings.Repeat("a", 21)
+		defer func() {
+			Options.NodeBalancerPrefix = prefix
+			Options.LoadBalancerType = ""
+			Options.EnableRouteController = rtEnabled
+			Options.VPCNames = ""
+			Options.NodeBalancerBackendIPv4SubnetID = 0
+			Options.NodeBalancerBackendIPv4SubnetName = ""
+			vpcIDs = map[string]int{}
+			subnetIDs = map[string]int{}
+		}()
+		_, err := newCloud()
+		t.Log(err)
+		require.Error(t, err, "expected error if nodebalancer-prefix is empty")
+		require.ErrorContains(t, err, "nodebalancer-prefix cannot be empty")
+	})
 }
 
 func Test_linodeCloud_LoadBalancer(t *testing.T) {

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -149,12 +149,8 @@ func TestNewCloud(t *testing.T) {
 		}()
 		_, err := newCloud()
 		t.Log(err)
-		if !assert.Error(t, err, "expected error if nodebalancer-prefix is longer than 19 chars") {
-			t.Errorf("No error when nodebalancer-prefix is longer 19 than")
-		}
-		if !assert.ErrorContains(t, err, "nodebalancer-prefix") {
-			t.Errorf("Error message does not concern nodebalancer-prefix: %s", err)
-		}
+		require.Error(t, err, "expected error if nodebalancer-prefix is longer than 19 chars")
+		require.ErrorContains(t, err, "nodebalancer-prefix")
 	})
 }
 

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -163,7 +163,7 @@ func TestNewCloud(t *testing.T) {
 		require.ErrorContains(t, err, "nodebalancer-prefix must be no empty")
 	})
 
-	t.Run("should fail if nodebalancer-prefix name validation", func(t *testing.T) {
+	t.Run("should fail if not validated nodebalancer-prefix", func(t *testing.T) {
 		prefix := Options.NodeBalancerPrefix
 		rtEnabled := Options.EnableRouteController
 		Options.EnableRouteController = false

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -227,7 +227,7 @@ func (l *loadbalancers) cleanupOldNodeBalancer(ctx context.Context, service *v1.
 // GetLoadBalancer will not modify service.
 func (l *loadbalancers) GetLoadBalancerName(_ context.Context, _ string, _ *v1.Service) string {
 	unixNano := strconv.FormatInt(time.Now().UnixNano(), 16)
-	return fmt.Sprintf("%s-%s", Options.LoadBalancerPrefix, unixNano[len(unixNano)-12:])
+	return fmt.Sprintf("%s-%s", Options.NodeBalancerPrefix, unixNano[len(unixNano)-12:])
 }
 
 // GetLoadBalancer returns the *v1.LoadBalancerStatus of service.

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -227,7 +227,7 @@ func (l *loadbalancers) cleanupOldNodeBalancer(ctx context.Context, service *v1.
 // GetLoadBalancer will not modify service.
 func (l *loadbalancers) GetLoadBalancerName(_ context.Context, _ string, _ *v1.Service) string {
 	unixNano := strconv.FormatInt(time.Now().UnixNano(), 16)
-	return fmt.Sprintf("ccm-%s", unixNano[len(unixNano)-12:])
+	return fmt.Sprintf("%s%s", Options.LoadBalancerPrefix, unixNano[len(unixNano)-12:])
 }
 
 // GetLoadBalancer returns the *v1.LoadBalancerStatus of service.

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -227,7 +227,7 @@ func (l *loadbalancers) cleanupOldNodeBalancer(ctx context.Context, service *v1.
 // GetLoadBalancer will not modify service.
 func (l *loadbalancers) GetLoadBalancerName(_ context.Context, _ string, _ *v1.Service) string {
 	unixNano := strconv.FormatInt(time.Now().UnixNano(), 16)
-	return fmt.Sprintf("%s%s", Options.LoadBalancerPrefix, unixNano[len(unixNano)-12:])
+	return fmt.Sprintf("%s-%s", Options.LoadBalancerPrefix, unixNano[len(unixNano)-12:])
 }
 
 // GetLoadBalancer returns the *v1.LoadBalancerStatus of service.

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -156,7 +156,7 @@ spec:
             {{- if .Values.nodeBalancerBackendIPv4Subnet }}
             - --nodebalancer-backend-ipv4-subnet={{ .Values.nodeBalancerBackendIPv4Subnet }}
             {{- end }}
-            {{- if .Values.nodeBalancerBackendIPv4Subnet }}
+            {{- if .Values.nodeBalancerPrefix }}
             - --nodebalancer-prefix={{ .Values.nodeBalancerPrefix }}
             {{- end }}
             {{- if .Values.extraArgs }}

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -156,6 +156,9 @@ spec:
             {{- if .Values.nodeBalancerBackendIPv4Subnet }}
             - --nodebalancer-backend-ipv4-subnet={{ .Values.nodeBalancerBackendIPv4Subnet }}
             {{- end }}
+            {{- if .Values.nodeBalancerBackendIPv4Subnet }}
+            - --nodebalancer-prefix={{ .Values.nodeBalancerPrefix }}
+            {{- end }}
             {{- if .Values.extraArgs }}
             {{- toYaml .Values.extraArgs | nindent 12 }}
             {{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -116,6 +116,9 @@ tolerations:
 # nodeBalancerBackendIPv4SubnetName is the subnet name to use for the backend ips of the NodeBalancer
 # nodeBalancerBackendIPv4SubnetName: ""
 
+# nodeBalancerPrefix is used to add prefix for nodeBalacer name. Default is "ccm"
+# nodeBalancerPrefix: ""
+
 # This section adds the ability to pass environment variables to adjust CCM defaults
 # https://github.com/linode/linode-cloud-controller-manager/blob/master/cloud/linode/loadbalancers.go
 # LINODE_HOSTNAME_ONLY_INGRESS type bool is supported

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -116,7 +116,7 @@ tolerations:
 # nodeBalancerBackendIPv4SubnetName is the subnet name to use for the backend ips of the NodeBalancer
 # nodeBalancerBackendIPv4SubnetName: ""
 
-# nodeBalancerPrefix is used to add prefix for nodeBalacer name. Default is "ccm"
+# nodeBalancerPrefix is used to add prefix for nodeBalancer name. Default is "ccm"
 # nodeBalancerPrefix: ""
 
 # This section adds the ability to pass environment variables to adjust CCM defaults

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -53,7 +53,7 @@ The CCM supports the following flags:
 | `--enable-ipv6-for-loadbalancers` | `false` | Set both IPv4 and IPv6 addresses for all LoadBalancer services (when disabled, only IPv4 is used). This can also be configured per-service using the `service.beta.kubernetes.io/linode-loadbalancer-enable-ipv6-ingress` annotation. |
 | `--node-cidr-mask-size-ipv4` | `24` | ipv4 cidr mask size for pod cidrs allocated to nodes |
 | `--node-cidr-mask-size-ipv6` | `64` | ipv6 cidr mask size for pod cidrs allocated to nodes |
-| `--nodebalancer-prefix` | `ccm` | Name prefix for LoadBalancers. (max. 19 char.) |
+| `--nodebalancer-prefix` | `ccm` | Name prefix for NoadBalancers. |
 
 ## Configuration Methods
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -53,6 +53,7 @@ The CCM supports the following flags:
 | `--enable-ipv6-for-loadbalancers` | `false` | Set both IPv4 and IPv6 addresses for all LoadBalancer services (when disabled, only IPv4 is used). This can also be configured per-service using the `service.beta.kubernetes.io/linode-loadbalancer-enable-ipv6-ingress` annotation. |
 | `--node-cidr-mask-size-ipv4` | `24` | ipv4 cidr mask size for pod cidrs allocated to nodes |
 | `--node-cidr-mask-size-ipv6` | `64` | ipv6 cidr mask size for pod cidrs allocated to nodes |
+| `--nodebalancer-prefix` | `ccm` | Name prefix for LoadBalancers. (max. 19 char.) |
 
 ## Configuration Methods
 

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 	command.Flags().IntVar(&linode.Options.NodeBalancerBackendIPv4SubnetID, "nodebalancer-backend-ipv4-subnet-id", 0, "ipv4 subnet id to use for NodeBalancer backends")
 	command.Flags().StringVar(&linode.Options.NodeBalancerBackendIPv4SubnetName, "nodebalancer-backend-ipv4-subnet-name", "", "ipv4 subnet name to use for NodeBalancer backends")
 	command.Flags().BoolVar(&linode.Options.DisableNodeBalancerVPCBackends, "disable-nodebalancer-vpc-backends", false, "disables nodebalancer backends in VPCs (when enabled, nodebalancers will only have private IPs as backends for backward compatibility)")
-	command.Flags().StringVar(&linode.Options.LoadBalancerPrefix, "load-balancer-prefix", "ccm-", "Name prefix for LoadBalancers. (Max 20 char.)")
+	command.Flags().StringVar(&linode.Options.LoadBalancerPrefix, "load-balancer-prefix", "ccm-", "Name prefix for LoadBalancers. (max. 20 char.)")
 
 	// Set static flags
 	command.Flags().VisitAll(func(fl *pflag.Flag) {

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 	command.Flags().IntVar(&linode.Options.NodeBalancerBackendIPv4SubnetID, "nodebalancer-backend-ipv4-subnet-id", 0, "ipv4 subnet id to use for NodeBalancer backends")
 	command.Flags().StringVar(&linode.Options.NodeBalancerBackendIPv4SubnetName, "nodebalancer-backend-ipv4-subnet-name", "", "ipv4 subnet name to use for NodeBalancer backends")
 	command.Flags().BoolVar(&linode.Options.DisableNodeBalancerVPCBackends, "disable-nodebalancer-vpc-backends", false, "disables nodebalancer backends in VPCs (when enabled, nodebalancers will only have private IPs as backends for backward compatibility)")
-	command.Flags().StringVar(&linode.Options.NodeBalancerPrefix, "nodebalancer-prefix", "ccm", fmt.Sprintf("Name prefix for NoadBalancers. (max. %s char.)", linode.NodeBalancerPrefixCharLimit))
+	command.Flags().StringVar(&linode.Options.NodeBalancerPrefix, "nodebalancer-prefix", "ccm", fmt.Sprintf("Name prefix for NoadBalancers. (max. %v char.)", linode.NodeBalancerPrefixCharLimit))
 
 	// Set static flags
 	command.Flags().VisitAll(func(fl *pflag.Flag) {

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 	command.Flags().IntVar(&linode.Options.NodeBalancerBackendIPv4SubnetID, "nodebalancer-backend-ipv4-subnet-id", 0, "ipv4 subnet id to use for NodeBalancer backends")
 	command.Flags().StringVar(&linode.Options.NodeBalancerBackendIPv4SubnetName, "nodebalancer-backend-ipv4-subnet-name", "", "ipv4 subnet name to use for NodeBalancer backends")
 	command.Flags().BoolVar(&linode.Options.DisableNodeBalancerVPCBackends, "disable-nodebalancer-vpc-backends", false, "disables nodebalancer backends in VPCs (when enabled, nodebalancers will only have private IPs as backends for backward compatibility)")
-	command.Flags().StringVar(&linode.Options.LoadBalancerPrefix, "load-balancer-prefix", "ccm-", "Name prefix for LoadBalancers")
+	command.Flags().StringVar(&linode.Options.LoadBalancerPrefix, "load-balancer-prefix", "ccm-", "Name prefix for LoadBalancers. (Max 20 char.)")
 
 	// Set static flags
 	command.Flags().VisitAll(func(fl *pflag.Flag) {

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 	command.Flags().IntVar(&linode.Options.NodeBalancerBackendIPv4SubnetID, "nodebalancer-backend-ipv4-subnet-id", 0, "ipv4 subnet id to use for NodeBalancer backends")
 	command.Flags().StringVar(&linode.Options.NodeBalancerBackendIPv4SubnetName, "nodebalancer-backend-ipv4-subnet-name", "", "ipv4 subnet name to use for NodeBalancer backends")
 	command.Flags().BoolVar(&linode.Options.DisableNodeBalancerVPCBackends, "disable-nodebalancer-vpc-backends", false, "disables nodebalancer backends in VPCs (when enabled, nodebalancers will only have private IPs as backends for backward compatibility)")
-	command.Flags().StringVar(&linode.Options.LoadBalancerPrefix, "load-balancer-prefix", "ccm", "Name prefix for LoadBalancers. (max. 19 char.)")
+	command.Flags().StringVar(&linode.Options.NodeBalancerPrefix, "nodebalancer-prefix", "ccm", "Name prefix for LoadBalancers. (max. 19 char.)")
 
 	// Set static flags
 	command.Flags().VisitAll(func(fl *pflag.Flag) {

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 	command.Flags().IntVar(&linode.Options.NodeBalancerBackendIPv4SubnetID, "nodebalancer-backend-ipv4-subnet-id", 0, "ipv4 subnet id to use for NodeBalancer backends")
 	command.Flags().StringVar(&linode.Options.NodeBalancerBackendIPv4SubnetName, "nodebalancer-backend-ipv4-subnet-name", "", "ipv4 subnet name to use for NodeBalancer backends")
 	command.Flags().BoolVar(&linode.Options.DisableNodeBalancerVPCBackends, "disable-nodebalancer-vpc-backends", false, "disables nodebalancer backends in VPCs (when enabled, nodebalancers will only have private IPs as backends for backward compatibility)")
-	command.Flags().StringVar(&linode.Options.LoadBalancerPrefix, "load-balancer-prefix", "ccm-", "Name prefix for LoadBalancers. (max. 20 char.)")
+	command.Flags().StringVar(&linode.Options.LoadBalancerPrefix, "load-balancer-prefix", "ccm", "Name prefix for LoadBalancers. (max. 19 char.)")
 
 	// Set static flags
 	command.Flags().VisitAll(func(fl *pflag.Flag) {

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func main() {
 	command.Flags().IntVar(&linode.Options.NodeBalancerBackendIPv4SubnetID, "nodebalancer-backend-ipv4-subnet-id", 0, "ipv4 subnet id to use for NodeBalancer backends")
 	command.Flags().StringVar(&linode.Options.NodeBalancerBackendIPv4SubnetName, "nodebalancer-backend-ipv4-subnet-name", "", "ipv4 subnet name to use for NodeBalancer backends")
 	command.Flags().BoolVar(&linode.Options.DisableNodeBalancerVPCBackends, "disable-nodebalancer-vpc-backends", false, "disables nodebalancer backends in VPCs (when enabled, nodebalancers will only have private IPs as backends for backward compatibility)")
+	command.Flags().StringVar(&linode.Options.LoadBalancerPrefix, "load-balancer-prefix", "ccm-", "Name prefix for LoadBalancers")
 
 	// Set static flags
 	command.Flags().VisitAll(func(fl *pflag.Flag) {

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 	command.Flags().IntVar(&linode.Options.NodeBalancerBackendIPv4SubnetID, "nodebalancer-backend-ipv4-subnet-id", 0, "ipv4 subnet id to use for NodeBalancer backends")
 	command.Flags().StringVar(&linode.Options.NodeBalancerBackendIPv4SubnetName, "nodebalancer-backend-ipv4-subnet-name", "", "ipv4 subnet name to use for NodeBalancer backends")
 	command.Flags().BoolVar(&linode.Options.DisableNodeBalancerVPCBackends, "disable-nodebalancer-vpc-backends", false, "disables nodebalancer backends in VPCs (when enabled, nodebalancers will only have private IPs as backends for backward compatibility)")
-	command.Flags().StringVar(&linode.Options.NodeBalancerPrefix, "nodebalancer-prefix", "ccm", "Name prefix for LoadBalancers. (max. 19 char.)")
+	command.Flags().StringVar(&linode.Options.NodeBalancerPrefix, "nodebalancer-prefix", "ccm", fmt.Sprintf("Name prefix for NoadBalancers. (max. %s char.)", linode.NodeBalancerPrefixCharLimit))
 
 	// Set static flags
 	command.Flags().VisitAll(func(fl *pflag.Flag) {


### PR DESCRIPTION
This PR introduces a flag that allows you to replace the "ccm-" prefix with any string of up to 20 characters.

This change allows you to set a cluster name as a prefix and trace Node Balancers more easily.

General:
1. [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
1. [x] Have you checked to ensure there aren't other open or closed [Pull Requests](https://github.com/linode/pulls) for the same bug/feature/question?


### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

