### PR TITLE
[improvement] : remove deprecated vpcname flag

### DIFF
--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -34,12 +34,10 @@ var supportedLoadBalancerTypes = []string{ciliumLBType, nodeBalancerLBType}
 // We expect it to be initialized with flags external to this package, likely in
 // main.go
 var Options struct {
-	KubeconfigFlag           *pflag.Flag
-	LinodeGoDebug            bool
-	EnableRouteController    bool
-	EnableTokenHealthChecker bool
-	// Deprecated: use VPCNames instead
-	VPCName                           string
+	KubeconfigFlag                    *pflag.Flag
+	LinodeGoDebug                     bool
+	EnableRouteController             bool
+	EnableTokenHealthChecker          bool
 	VPCNames                          string
 	SubnetNames                       string
 	LoadBalancerType                  string
@@ -136,15 +134,6 @@ func newCloud() (cloudprovider.Interface, error) {
 		}
 
 		healthChecker = newHealthChecker(linodeClient, tokenHealthCheckPeriod, Options.GlobalStopChannel)
-	}
-
-	if Options.VPCName != "" && Options.VPCNames != "" {
-		return nil, fmt.Errorf("cannot have both vpc-name and vpc-names set")
-	}
-
-	if Options.VPCName != "" {
-		klog.Warningf("vpc-name flag is deprecated. Use vpc-names instead")
-		Options.VPCNames = Options.VPCName
 	}
 
 	// SubnetNames can't be used without VPCNames also being set

--- a/cloud/linode/cloud_test.go
+++ b/cloud/linode/cloud_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	cloudprovider "k8s.io/cloud-provider"
 
 	"github.com/linode/linode-cloud-controller-manager/cloud/linode/client/mocks"
@@ -22,14 +21,14 @@ func TestNewCloudRouteControllerDisabled(t *testing.T) {
 	t.Setenv("LINODE_REQUEST_TIMEOUT_SECONDS", "10")
 
 	t.Run("should not fail if vpc is empty and routecontroller is disabled", func(t *testing.T) {
-		Options.VPCName = ""
+		Options.VPCNames = ""
 		Options.EnableRouteController = false
 		_, err := newCloud()
 		assert.NoError(t, err)
 	})
 
 	t.Run("fail if vpcname is empty and routecontroller is enabled", func(t *testing.T) {
-		Options.VPCName = ""
+		Options.VPCNames = ""
 		Options.EnableRouteController = true
 		_, err := newCloud()
 		assert.Error(t, err)
@@ -56,28 +55,6 @@ func TestNewCloud(t *testing.T) {
 		t.Setenv("LINODE_REGION", "")
 		_, err := newCloud()
 		assert.Error(t, err, "expected error when linode region is empty")
-	})
-
-	t.Run("should fail if both vpcname and vpcnames are set", func(t *testing.T) {
-		Options.VPCName = "tt"
-		Options.VPCNames = "tt"
-		defer func() {
-			Options.VPCName = ""
-			Options.VPCNames = ""
-		}()
-		_, err := newCloud()
-		assert.Error(t, err, "expected error when both vpcname and vpcnames are set")
-	})
-
-	t.Run("should not fail if deprecated vpcname is set", func(t *testing.T) {
-		Options.VPCName = "tt"
-		defer func() {
-			Options.VPCName = ""
-			Options.VPCNames = ""
-		}()
-		_, err := newCloud()
-		require.NoError(t, err, "expected no error if deprecated flag vpcname is set")
-		assert.Equal(t, "tt", Options.VPCNames, "expected vpcnames to be set to vpcname")
 	})
 
 	t.Run("should fail if both nodeBalancerBackendIPv4SubnetID and nodeBalancerBackendIPv4SubnetName are set", func(t *testing.T) {

--- a/deploy/chart/templates/daemonset.yaml
+++ b/deploy/chart/templates/daemonset.yaml
@@ -79,13 +79,6 @@ spec:
             {{- if and .Values.routeController .Values.routeController.vpcNames }}
             {{- $vpcNames = .Values.routeController.vpcNames }}
             {{- end }}
-            {{- $vpcName := .Values.vpcName }}
-            {{- if and .Values.routeController .Values.routeController.vpcName }}
-            {{- $vpcName = .Values.routeController.vpcName }}
-            {{- end }}
-            {{- if and $vpcName $vpcNames }}
-            {{- fail "Both vpcName and vpcNames are set. Please use only vpcNames." }}
-            {{- end }}
             {{- $subnetNames := .Values.subnetNames }}
             {{- if and .Values.routeController .Values.routeController.subnetNames }}
             {{- $subnetNames = .Values.routeController.subnetNames }}
@@ -106,8 +99,8 @@ spec:
             {{- end }}
             {{- if .Values.routeController }}
             - --enable-route-controller=true
-            {{- if not (or $vpcName $vpcNames) }}
-            {{- fail "Neither vpcName nor vpcNames is set. Please set one of them." }}
+            {{- if not $vpcNames }}
+            {{- fail "vpcNames not set. Please set it when enabling route_controller for VPCs." }}
             {{- end }}
             {{- if not $clusterCIDR }}
             {{- fail "clusterCIDR is required if route-controller is enabled" }}
@@ -119,9 +112,6 @@ spec:
             {{- end }}
             {{- with $vpcNames }}
             - --vpc-names={{ . }}
-            {{- end }}
-            {{- with $vpcName }}
-            - --vpc-name={{ . }}
             {{- end }}
             {{- with $subnetNames }}
             - --subnet-names={{ . }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -75,7 +75,6 @@ tolerations:
 
 # This section adds ability to enable route-controller for ccm
 # routeController:
-#   vpcName: <name of VPC> [Deprecated: use vpcNames instead]
 #   vpcNames: <comma separated list of vpc names>
 #   subnetNames: <comma separated list of subnet names>
 #   clusterCIDR: 10.192.0.0/10
@@ -88,7 +87,6 @@ tolerations:
 # nodeCIDRMaskSizeIPv6: 64
 
 # vpcs and subnets that node internal IPs will be assigned from (not required if already specified in routeController)
-# vpcName: <name of VPC> [Deprecated: use vpcNames instead]
 # vpcNames: <comma separated list of vpc names>
 # subnetNames: <comma separated list of subnet names>
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,6 @@ func main() {
 	command.Flags().BoolVar(&linode.Options.LinodeGoDebug, "linodego-debug", false, "enables debug output for the LinodeAPI wrapper")
 	command.Flags().BoolVar(&linode.Options.EnableRouteController, "enable-route-controller", false, "enables route_controller for ccm")
 	command.Flags().BoolVar(&linode.Options.EnableTokenHealthChecker, "enable-token-health-checker", false, "enables Linode API token health checker")
-	command.Flags().StringVar(&linode.Options.VPCName, "vpc-name", "", "[deprecated: use vpc-names instead] vpc name whose routes will be managed by route-controller")
 	command.Flags().StringVar(&linode.Options.VPCNames, "vpc-names", "", "comma separated vpc names whose routes will be managed by route-controller")
 	command.Flags().StringVar(&linode.Options.SubnetNames, "subnet-names", "default", "comma separated subnet names whose routes will be managed by route-controller (requires vpc-names flag to also be set)")
 	command.Flags().StringVar(&linode.Options.LoadBalancerType, "load-balancer-type", "nodebalancer", "configures which type of load-balancing to use for LoadBalancer Services (options: nodebalancer, cilium-bgp)")


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:
Its been more than 8+ months since we deprecated vpcname flag. This PR removes the deprecated flag.
* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

