### PR TITLE
[feat] add support for using linode interfaces (beta-only)

### DIFF
--- a/cloud/linode/client/client.go
+++ b/cloud/linode/client/client.go
@@ -36,6 +36,9 @@ type Client interface {
 
 	UpdateInstanceConfigInterface(context.Context, int, int, int, linodego.InstanceConfigInterfaceUpdateOptions) (*linodego.InstanceConfigInterface, error)
 
+	ListInterfaces(ctx context.Context, linodeID int, opts *linodego.ListOptions) ([]linodego.LinodeInterface, error)
+	UpdateInterface(ctx context.Context, linodeID int, interfaceID int, opts linodego.LinodeInterfaceUpdateOptions) (*linodego.LinodeInterface, error)
+
 	GetVPC(context.Context, int) (*linodego.VPC, error)
 	GetVPCSubnet(context.Context, int, int) (*linodego.VPCSubnet, error)
 	ListVPCs(context.Context, *linodego.ListOptions) ([]linodego.VPC, error)

--- a/cloud/linode/client/client_with_metrics.go
+++ b/cloud/linode/client/client_with_metrics.go
@@ -306,6 +306,19 @@ func (_d ClientWithPrometheus) ListInstances(ctx context.Context, lp1 *linodego.
 	return _d.base.ListInstances(ctx, lp1)
 }
 
+// ListInterfaces implements Client
+func (_d ClientWithPrometheus) ListInterfaces(ctx context.Context, linodeID int, opts *linodego.ListOptions) (la1 []linodego.LinodeInterface, err error) {
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		ClientMethodCounterVec.WithLabelValues("ListInterfaces", result).Inc()
+	}()
+	return _d.base.ListInterfaces(ctx, linodeID, opts)
+}
+
 // ListNodeBalancerConfigs implements Client
 func (_d ClientWithPrometheus) ListNodeBalancerConfigs(ctx context.Context, i1 int, lp1 *linodego.ListOptions) (na1 []linodego.NodeBalancerConfig, err error) {
 	defer func() {
@@ -460,6 +473,19 @@ func (_d ClientWithPrometheus) UpdateInstanceConfigInterface(ctx context.Context
 		ClientMethodCounterVec.WithLabelValues("UpdateInstanceConfigInterface", result).Inc()
 	}()
 	return _d.base.UpdateInstanceConfigInterface(ctx, i1, i2, i3, i4)
+}
+
+// UpdateInterface implements Client
+func (_d ClientWithPrometheus) UpdateInterface(ctx context.Context, linodeID int, interfaceID int, opts linodego.LinodeInterfaceUpdateOptions) (lp1 *linodego.LinodeInterface, err error) {
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		ClientMethodCounterVec.WithLabelValues("UpdateInterface", result).Inc()
+	}()
+	return _d.base.UpdateInterface(ctx, linodeID, interfaceID, opts)
 }
 
 // UpdateNodeBalancer implements Client

--- a/cloud/linode/client/mocks/mock_client.go
+++ b/cloud/linode/client/mocks/mock_client.go
@@ -345,6 +345,21 @@ func (mr *MockClientMockRecorder) ListInstances(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstances", reflect.TypeOf((*MockClient)(nil).ListInstances), arg0, arg1)
 }
 
+// ListInterfaces mocks base method.
+func (m *MockClient) ListInterfaces(arg0 context.Context, arg1 int, arg2 *linodego.ListOptions) ([]linodego.LinodeInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInterfaces", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]linodego.LinodeInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListInterfaces indicates an expected call of ListInterfaces.
+func (mr *MockClientMockRecorder) ListInterfaces(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInterfaces", reflect.TypeOf((*MockClient)(nil).ListInterfaces), arg0, arg1, arg2)
+}
+
 // ListNodeBalancerConfigs mocks base method.
 func (m *MockClient) ListNodeBalancerConfigs(arg0 context.Context, arg1 int, arg2 *linodego.ListOptions) ([]linodego.NodeBalancerConfig, error) {
 	m.ctrl.T.Helper()
@@ -522,6 +537,21 @@ func (m *MockClient) UpdateInstanceConfigInterface(arg0 context.Context, arg1, a
 func (mr *MockClientMockRecorder) UpdateInstanceConfigInterface(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInstanceConfigInterface", reflect.TypeOf((*MockClient)(nil).UpdateInstanceConfigInterface), arg0, arg1, arg2, arg3, arg4)
+}
+
+// UpdateInterface mocks base method.
+func (m *MockClient) UpdateInterface(arg0 context.Context, arg1, arg2 int, arg3 linodego.LinodeInterfaceUpdateOptions) (*linodego.LinodeInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateInterface", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*linodego.LinodeInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateInterface indicates an expected call of UpdateInterface.
+func (mr *MockClientMockRecorder) UpdateInterface(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInterface", reflect.TypeOf((*MockClient)(nil).UpdateInterface), arg0, arg1, arg2, arg3)
 }
 
 // UpdateNodeBalancer mocks base method.

--- a/cloud/linode/route_controller.go
+++ b/cloud/linode/route_controller.go
@@ -246,11 +246,13 @@ func (r *routes) handleInterfaces(ctx context.Context, intfRoutes []string, lino
 	if instance.InterfaceGeneration == linodego.GenerationLinode {
 		interfaceUpdateOptions := linodego.LinodeInterfaceUpdateOptions{
 			VPC: &linodego.VPCInterfaceCreateOptions{
-				IPv4: &linodego.VPCInterfaceIPv4CreateOptions{Ranges: linodeInterfaceRoutes},
+				SubnetID: intfVPCIP.SubnetID,
+				IPv4:     &linodego.VPCInterfaceIPv4CreateOptions{Ranges: linodeInterfaceRoutes},
 			},
 		}
 		resp, err := r.client.UpdateInterface(ctx, instance.ID, intfVPCIP.InterfaceID, interfaceUpdateOptions)
 		if err != nil {
+			klog.V(4).Infof("Unable to update legacy interface %d for node %s", intfVPCIP.InterfaceID, route.TargetNode)
 			return err
 		}
 		klog.V(4).Infof("Updated routes for node %s. Current routes: %v", route.TargetNode, resp.VPC.IPv4.Ranges)
@@ -260,6 +262,7 @@ func (r *routes) handleInterfaces(ctx context.Context, intfRoutes []string, lino
 		}
 		resp, err := r.client.UpdateInstanceConfigInterface(ctx, instance.ID, intfVPCIP.ConfigID, intfVPCIP.InterfaceID, interfaceUpdateOptions)
 		if err != nil {
+			klog.V(4).Infof("Unable to update linode interface %d for node %s", intfVPCIP.InterfaceID, route.TargetNode)
 			return err
 		}
 		klog.V(4).Infof("Updated routes for node %s. Current routes: %v", route.TargetNode, resp.IPRanges)

--- a/cloud/linode/route_controller_test.go
+++ b/cloud/linode/route_controller_test.go
@@ -393,6 +393,38 @@ func TestCreateRoute(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	interfaceWithVPCAndRoute := linodego.LinodeInterface{
+		ID: vpcIDs["dummy"],
+		VPC: &linodego.VPCInterface{
+			IPv4: linodego.VPCInterfaceIPv4{
+				Ranges: []linodego.VPCInterfaceIPv4Range{{Range: "10.10.10.0/24"}},
+			},
+		},
+	}
+	validInstance.InterfaceGeneration = linodego.GenerationLinode
+	t.Run("should return no error if instance exists, connected to VPC we add a route with linode interfaces", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mocks.NewMockClient(ctrl)
+		instanceCache := newInstances(client)
+		existingK8sCache := registeredK8sNodeCache
+		defer func() {
+			registeredK8sNodeCache = existingK8sCache
+		}()
+		registeredK8sNodeCache = newK8sNodeCache()
+		registeredK8sNodeCache.addNodeToCache(node)
+		routeController, err := newRoutes(client, instanceCache)
+		require.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(noRoutesInVPC, nil)
+		client.EXPECT().ListVPCIPv6Addresses(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]linodego.VPCIP{}, nil)
+		client.EXPECT().UpdateInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&interfaceWithVPCAndRoute, nil)
+		err = routeController.CreateRoute(ctx, "dummy", "dummy", route)
+		assert.NoError(t, err)
+	})
+	validInstance.InterfaceGeneration = ""
+
 	v6Route := &cloudprovider.Route{
 		Name:            "route2",
 		TargetNode:      types.NodeName(name),
@@ -552,6 +584,29 @@ func TestDeleteRoute(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	interfaceWitVPCAndNoRoute := linodego.LinodeInterface{
+		ID:  vpcIDs["dummy"],
+		VPC: &linodego.VPCInterface{IPv4: linodego.VPCInterfaceIPv4{Ranges: nil}},
+	}
+
+	validInstance.InterfaceGeneration = linodego.GenerationLinode
+	t.Run("should return no error if instance exists, connected to VPC, route doesn't exist and we try to delete route with linode interfaces", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mocks.NewMockClient(ctrl)
+		instanceCache := newInstances(client)
+		routeController, err := newRoutes(client, instanceCache)
+		require.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(noRoutesInVPC, nil)
+		client.EXPECT().ListVPCIPv6Addresses(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]linodego.VPCIP{}, nil)
+		client.EXPECT().UpdateInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&interfaceWitVPCAndNoRoute, nil)
+		err = routeController.DeleteRoute(ctx, "dummy", route)
+		assert.NoError(t, err)
+	})
+	validInstance.InterfaceGeneration = ""
+
 	routesInVPC := []linodego.VPCIP{
 		{
 			Address:      &vpcIP,
@@ -581,6 +636,23 @@ func TestDeleteRoute(t *testing.T) {
 		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(routesInVPC, nil)
 		client.EXPECT().ListVPCIPv6Addresses(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]linodego.VPCIP{}, nil)
 		client.EXPECT().UpdateInstanceConfigInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&instanceConfigIntfWithVPCAndNoRoute, nil)
+		err = routeController.DeleteRoute(ctx, "dummy", route)
+		assert.NoError(t, err)
+	})
+
+	validInstance.InterfaceGeneration = linodego.GenerationLinode
+	t.Run("should return no error if instance exists, connected to VPC and route is deleted with linode interfaces", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mocks.NewMockClient(ctrl)
+		instanceCache := newInstances(client)
+		routeController, err := newRoutes(client, instanceCache)
+		require.NoError(t, err)
+
+		client.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{validInstance}, nil)
+		client.EXPECT().ListVPCIPAddresses(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(routesInVPC, nil)
+		client.EXPECT().ListVPCIPv6Addresses(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]linodego.VPCIP{}, nil)
+		client.EXPECT().UpdateInterface(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&interfaceWitVPCAndNoRoute, nil)
 		err = routeController.DeleteRoute(ctx, "dummy", route)
 		assert.NoError(t, err)
 	})

--- a/cloud/linode/route_controller_test.go
+++ b/cloud/linode/route_controller_test.go
@@ -394,7 +394,7 @@ func TestCreateRoute(t *testing.T) {
 	})
 
 	interfaceWithVPCAndRoute := linodego.LinodeInterface{
-		ID: vpcIDs["dummy"],
+		ID: services.VpcIDs["dummy"],
 		VPC: &linodego.VPCInterface{
 			IPv4: linodego.VPCInterfaceIPv4{
 				Ranges: []linodego.VPCInterfaceIPv4Range{{Range: "10.10.10.0/24"}},
@@ -406,7 +406,7 @@ func TestCreateRoute(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		client := mocks.NewMockClient(ctrl)
-		instanceCache := newInstances(client)
+		instanceCache := services.NewInstances(client)
 		existingK8sCache := registeredK8sNodeCache
 		defer func() {
 			registeredK8sNodeCache = existingK8sCache
@@ -585,7 +585,7 @@ func TestDeleteRoute(t *testing.T) {
 	})
 
 	interfaceWitVPCAndNoRoute := linodego.LinodeInterface{
-		ID:  vpcIDs["dummy"],
+		ID:  services.VpcIDs["dummy"],
 		VPC: &linodego.VPCInterface{IPv4: linodego.VPCInterfaceIPv4{Ranges: nil}},
 	}
 
@@ -594,7 +594,7 @@ func TestDeleteRoute(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		client := mocks.NewMockClient(ctrl)
-		instanceCache := newInstances(client)
+		instanceCache := services.NewInstances(client)
 		routeController, err := newRoutes(client, instanceCache)
 		require.NoError(t, err)
 
@@ -645,7 +645,7 @@ func TestDeleteRoute(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		client := mocks.NewMockClient(ctrl)
-		instanceCache := newInstances(client)
+		instanceCache := services.NewInstances(client)
 		routeController, err := newRoutes(client, instanceCache)
 		require.NoError(t, err)
 

--- a/cloud/nodeipam/ipam/cloud_allocator_test.go
+++ b/cloud/nodeipam/ipam/cloud_allocator_test.go
@@ -50,6 +50,40 @@ type testCase struct {
 	instance       *linodego.Instance
 }
 
+func TestGetIPv6RangeFromLinodeInterface(t *testing.T) {
+	for _, tc := range []struct {
+		iface         linodego.LinodeInterface
+		expectedRange string
+	}{
+		{linodego.LinodeInterface{
+			ID: 123,
+			VPC: &linodego.VPCInterface{
+				IPv6: linodego.VPCInterfaceIPv6{},
+			},
+		}, ""},
+		{linodego.LinodeInterface{
+			ID: 123,
+			VPC: &linodego.VPCInterface{
+				IPv6: linodego.VPCInterfaceIPv6{
+					Ranges: []linodego.VPCInterfaceIPv6Range{{Range: "2001:db8::/64"}, {Range: "2001:db9::/64"}},
+				},
+			},
+		}, "2001:db8::/64"},
+		{linodego.LinodeInterface{
+			ID: 123,
+			VPC: &linodego.VPCInterface{
+				IPv6: linodego.VPCInterfaceIPv6{
+					SLAAC: []linodego.VPCInterfaceIPv6SLAAC{{Range: "2001:db8::/64"}, {Range: "2001:db9::/64"}},
+				},
+			},
+		}, "2001:db8::/64"},
+	} {
+		if getIPv6RangeFromLinodeInterface(tc.iface) != tc.expectedRange {
+			t.Errorf("getIPv6RangeFromLinodeInterface(%+v) = %s, want %s", tc.iface, getIPv6RangeFromLinodeInterface(tc.iface), tc.expectedRange)
+		}
+	}
+}
+
 func TestOccupyPreExistingCIDR(t *testing.T) {
 	// all tests operate on a single node
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
[Linode Interfaces is in beta](https://techdocs.akamai.com/linode-api/reference/post-linode-interface). This adds support so the CCM can work on Linodes using the new linode interfaces.

**NOTE**: If you want to test this locally you need to opt in to the Linode Interfaces beta AND the ability to use VPC-only backends (see https://github.com/linode/cluster-api-provider-linode/pull/803).

## Testing with linode interfaces
1. Make a CAPL cluster that uses the new network interfaces (follow the Testing section in https://github.com/linode/cluster-api-provider-linode/pull/821) but update the test-cluster.yaml BEFORE APPLYING IT to have the following:
- `adumaine/linode-cloud-controller-manager:linode-interfaces` for the CCM repo and version, e.g.:
```
<snip>
---
apiVersion: addons.cluster.x-k8s.io/v1alpha1
kind: HelmChartProxy
metadata:
  name: test-cluster-linode-cloud-controller-manager
  namespace: default
spec:
  chartName: ccm-linode
  clusterSelector:
    matchLabels:
      ccm: test-cluster-linode
  namespace: kube-system
  options:
    timeout: 5m
    wait: true
    waitForJobs: true
  repoURL: https://linode.github.io/linode-cloud-controller-manager/
  valuesTemplate: |
    routeController:
      vpcNames: {{ .InfraCluster.spec.vpcRef.name }}
      clusterCIDR: 10.0.0.0/8
      configureCloudRoutes: true
    secretRef:
      name: "linode-token-region"
    image:
      pullPolicy: IfNotPresent
      repository: adumaine/linode-cloud-controller-manager
      tag: linode-interfaces
<snip>
```
- VPC NBs by replacing the `LinodeMachineTemplate.Spec.Template.Spec.Interfaces` with:
```
      privateIP: false
      vpcRef:
        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
        kind: LinodeVPC
        name: test-cluster
```
and adding the following to the `LinodeCluster.Spec.Network`:
```
    enableVPCBackends: true
```
2. Apply the update cluster yaml:
```
kubectl apply -f test-cluster.yaml
```
3. Get the kubeconfig:
```
clusterctl get kubeconfig test-cluster > test-kubeconfig.yaml
```
4. Wait for the cluster to be ready
```
kubectl wait --for=condition=Ready cluster test-cluster --timeout=60s
```
5. Confirm CCM runs successfully with new network interfaces:
```
kubctl --kubeconfig test-kubeconfig.yaml -n kube-system logs -f ds/ccm-linode
```

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   6. if a PR introduces a breaking change it should include `[breaking]` in the title
   7. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

