### PR TITLE
[improvement] Prioritize Renovate security updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,11 @@
   ],
   "packageRules": [
     {
+      "matchCategories": ["security"],
+      "schedule": ["at any time"],
+      "prPriority": 10,
+    },
+    {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
     },


### PR DESCRIPTION
Ensure Renovate opens security-related dependency updates immediately instead of waiting for the regular schedule.