### PR TITLE
[test] Stabilize flaky e2e tests by replacing hard sleeps with polling loops

### DIFF
--- a/e2e/test/lb-created-with-invalid-ip/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-invalid-ip/chainsaw-test.yaml
@@ -73,21 +73,23 @@ spec:
         - script: 
             content: |
               set -euo pipefail
-              sleep 30
               invalid_ip=$(kubectl get configmap invalid-ip-config -o=jsonpath='{.data.InvalidIP}' -n $NAMESPACE)
               if [[ -z "$invalid_ip" ]]; then
                   echo "Error: No invalid ip found in configmap"
               fi
 
               annotation="service.beta.kubernetes.io/linode-loadbalancer-reserved-ipv4"
-              events=$(kubectl get events -n $NAMESPACE --field-selector reason=SyncLoadBalancerFailed --sort-by='.lastTimestamp' -o json)
-              message=$(echo $events | jq .items[0].message)
 
-              if [[ "$message" == *"Error syncing load balancer: failed to ensure load balancer: [400] Invalid IPv4 address"* ]]; then
-                echo "Warning event found"
-              else
-                echo "Warning event not found"
-              fi
+              for i in {1..10}; do
+                events=$(kubectl get events -n $NAMESPACE --field-selector reason=SyncLoadBalancerFailed --sort-by='.lastTimestamp' -o json)
+                message=$(echo $events | jq .items[0].message)
+
+                if [[ "$message" == *"Error syncing load balancer: failed to ensure load balancer: [400] Invalid IPv4 address"* ]]; then
+                  echo "Warning event found"
+                  break
+                fi
+                sleep 10
+              done
               
               service_ip=$(kubectl get svc svc-test -n $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
               if [[ "$service_ip" != "" ]]; then

--- a/e2e/test/lb-created-with-reserved-ip-change-ip-concurrently/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-reserved-ip-change-ip-concurrently/chainsaw-test.yaml
@@ -163,29 +163,32 @@ spec:
 
               parallel -j 2 patch_annotation ::: $reserved_ip2 "100.10.10.10"
 
-              sleep 20
+              for i in {1..10}; do
+                all_events=$(kubectl get events -n $NAMESPACE)
+                events=$(kubectl get events -n $NAMESPACE --field-selector reason=NodeBalancerIPChangeIgnored --sort-by='.lastTimestamp' -o json)
+                num_events=$(echo $events | jq '.items | length')
 
-              all_events=$(kubectl get events -n $NAMESPACE)
+                #k8s scheduler will flatten the work queue of updates for an object into a single reconcile call.
+                #If k8s scheduler squashes both the patches into 1 only 1 event is generated
 
-              events=$(kubectl get events -n $NAMESPACE --field-selector reason=NodeBalancerIPChangeIgnored --sort-by='.lastTimestamp' -o json)
-              num_events=$(echo $events | jq '.items | length')
+                if [[ num_events -eq 0 ]]; then
+                  sleep 10
+                  continue
+                fi
 
-              #k8s scheduler will flatten the work queue of updates for an object into a single reconcile call. 
-              #If k8s scheduler squashes both the patches into 1 only 1 event is generated
-
-              if [[ num_events -eq 0 ]]; then
-                echo "Warning event not found"
-              else
                 message=$(echo $events | jq .items[0].message)
                 if [[ "$message" =~ ^\"IPv4\ annotation\ changed\ to\ $reserved_ip2,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ || "$message" =~ ^\"IPv4\ annotation\ changed\ to\ 100.10.10.10,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
                   echo "First warning event found"
+                  break
                 elif [[ num_events -eq 2 ]]; then
                   message2=$(echo $events | jq .items[1].message)
                   if [[ "$message2" =~ ^\"IPv4\ annotation\ changed\ to\ $reserved_ip2,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ || "$message2" =~ ^\"IPv4\ annotation\ changed\ to\ 100.10.10.10,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
                     echo "Second warning event found"
+                    break
                   fi
                 fi
-              fi             
+                sleep 10
+              done
             check:
               ($error == null): true
               (contains($stdout, 'No reserved ip found in configmap')): false

--- a/e2e/test/lb-created-with-reserved-ip-change-ip-unreserved/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-reserved-ip-change-ip-unreserved/chainsaw-test.yaml
@@ -131,17 +131,16 @@ spec:
                 echo "Unable to update annotation"
               fi
 
-              sleep 20
+              for i in {1..10}; do
+                events=$(kubectl get events -n $NAMESPACE --field-selector reason=NodeBalancerIPChangeIgnored --sort-by='.lastTimestamp' -o json)
+                message=$(echo $events | jq .items[0].message)
 
-              events=$(kubectl get events -n $NAMESPACE --field-selector reason=NodeBalancerIPChangeIgnored --sort-by='.lastTimestamp' -o json)
-
-              message=$(echo $events | jq .items[0].message)
-
-              if [[ "$message" =~ ^\"IPv4\ annotation\ changed\ to\ $unreserved_ip,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
-                echo "Warning event found"
-              else
-                echo "Warning event not found"
-              fi
+                if [[ "$message" =~ ^\"IPv4\ annotation\ changed\ to\ $unreserved_ip,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
+                  echo "Warning event found"
+                  break
+                fi
+                sleep 10
+              done
             check:
               ($error == null): true
               (contains($stdout, 'Warning event found')): true

--- a/e2e/test/lb-created-with-reserved-ip-change-ip/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-reserved-ip-change-ip/chainsaw-test.yaml
@@ -159,17 +159,16 @@ spec:
                 echo "Unable to update annotation"
               fi
 
-              sleep 20
+              for i in {1..10}; do
+                events=$(kubectl get events -n $NAMESPACE --field-selector reason=NodeBalancerIPChangeIgnored --sort-by='.lastTimestamp' -o json)
+                message=$(echo $events | jq .items[0].message)
 
-              events=$(kubectl get events -n $NAMESPACE --field-selector reason=NodeBalancerIPChangeIgnored --sort-by='.lastTimestamp' -o json)
-
-              message=$(echo $events | jq .items[0].message)
-
-              if [[ "$message" =~ ^\"IPv4\ annotation\ changed\ to\ $reserved_ip2,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
-                echo "Warning event found"
-              else
-                echo "Warning event not found"
-              fi
+                if [[ "$message" =~ ^\"IPv4\ annotation\ changed\ to\ $reserved_ip2,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
+                  echo "Warning event found"
+                  break
+                fi
+                sleep 10
+              done
             check:
               ($error == null): true
               (contains($stdout, 'Warning event found')): true

--- a/e2e/test/lb-created-with-reserved-ip-linode-range/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-reserved-ip-linode-range/chainsaw-test.yaml
@@ -177,7 +177,7 @@ spec:
               #Run a curl command to the service ip
               URL="http://$service_ip:80/"
               for i in {1..10}; do
-                HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+                HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || true)
                 if [ "$HTTP_RESPONSE" -eq 200 ]; then
                    echo "Request was successful (HTTP 200)"
                    break

--- a/e2e/test/lb-created-with-reserved-ip-linode-range/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-reserved-ip-linode-range/chainsaw-test.yaml
@@ -174,15 +174,16 @@ spec:
                 echo "IPs do not match"
               fi
 
-              sleep 30
               #Run a curl command to the service ip
               URL="http://$service_ip:80/"
-              HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
-              if [ "$HTTP_RESPONSE" -eq 200 ]; then
-                 echo "Request was successful (HTTP 200)"
-              else
-                 echo "Request failed with response code: $HTTP_RESPONSE"
-              fi
+              for i in {1..10}; do
+                HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+                if [ "$HTTP_RESPONSE" -eq 200 ]; then
+                   echo "Request was successful (HTTP 200)"
+                   break
+                fi
+                sleep 10
+              done
             check:
               ($error == null): true
               (contains($stdout, 'No reserved ip found in configmap')): false

--- a/e2e/test/lb-created-with-reserved-ip-multiple-change-ip/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-reserved-ip-multiple-change-ip/chainsaw-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: c
+  name: lb-created-with-reserved-ip-multiple-change-ip
   labels:
     all:
     lke:
@@ -161,8 +161,6 @@ spec:
                 }
               }")
 
-              sleep 30
-
               patch2=$(kubectl patch service svc-test -n $NAMESPACE --patch "{
                 \"metadata\": {
                   \"annotations\": {
@@ -171,30 +169,25 @@ spec:
                 }
               }")
 
-              sleep 30
               if [[ "$patch" != "service/svc-test patched" ]]; then
                 echo "Unable to update annotation"
               fi
               if [[ "$patch2" != "service/svc-test patched" ]]; then
                 echo "Unable to update annotation"
               fi
-              
-              events=$(kubectl get events -n $NAMESPACE --field-selector reason=NodeBalancerIPChangeIgnored --sort-by='.lastTimestamp' -o json)
 
-              message=$(echo $events | jq .items[0].message)
-              message2=$(echo $events | jq .items[1].message)
+              for i in {1..10}; do
+                events=$(kubectl get events -n $NAMESPACE --field-selector reason=NodeBalancerIPChangeIgnored --sort-by='.lastTimestamp' -o json)
+                message=$(echo $events | jq .items[0].message)
+                message2=$(echo $events | jq .items[1].message)
 
-              if [[ "$message" =~ ^\"IPv4\ annotation\ changed\ to\ $reserved_ip2,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
-                echo "Warning event found"
-              else
-                echo "Warning event not found"
-              fi
-              
-              if [[ "$message2" =~ ^\"IPv4\ annotation\ changed\ to\ 100.10.10.10,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
-                echo "Warning event found"
-              else
-                echo "Warning event not found"
-              fi
+                if [[ "$message" =~ ^\"IPv4\ annotation\ changed\ to\ $reserved_ip2,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]] && \
+                   [[ "$message2" =~ ^\"IPv4\ annotation\ changed\ to\ 100.10.10.10,\ but\ NodeBalancer\ \([0-9]+\)\ IP\ cannot\ be\ updated\ after\ creation.\ It\ will\ remain\ $reserved_ip\"$ ]]; then
+                  echo "Warning event found"
+                  break
+                fi
+                sleep 10
+              done
             check:
               ($error == null): true
               (contains($stdout, 'No reserved ip found in configmap')): false

--- a/e2e/test/lb-created-with-reserved-ip-nb-range/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-reserved-ip-nb-range/chainsaw-test.yaml
@@ -206,15 +206,16 @@ spec:
                 echo "IPs do not match"
               fi
 
-              sleep 30
               #Run a curl command to the service ip
               URL="http://$service_ip:80/"
-              HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
-              if [ "$HTTP_RESPONSE" -eq 200 ]; then
-                 echo "Request was successful (HTTP 200)"
-              else
-                 echo "Request failed with response code: $HTTP_RESPONSE"
-              fi
+              for i in {1..10}; do
+                HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+                if [ "$HTTP_RESPONSE" -eq 200 ]; then
+                   echo "Request was successful (HTTP 200)"
+                   break
+                fi
+                sleep 10
+              done
             check:
               ($error == null): true
               (contains($stdout, 'No reserved ip found in configmap')): false

--- a/e2e/test/lb-created-with-reserved-ip-nb-range/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-reserved-ip-nb-range/chainsaw-test.yaml
@@ -209,7 +209,7 @@ spec:
               #Run a curl command to the service ip
               URL="http://$service_ip:80/"
               for i in {1..10}; do
-                HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+                HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || true)
                 if [ "$HTTP_RESPONSE" -eq 200 ]; then
                    echo "Request was successful (HTTP 200)"
                    break

--- a/e2e/test/lb-created-with-specified-nb-id-reserved/chainsaw-test.yaml
+++ b/e2e/test/lb-created-with-specified-nb-id-reserved/chainsaw-test.yaml
@@ -170,7 +170,6 @@ spec:
               else
                 echo "IPs do not match"
               fi
-              sleep 20
 
             check:
               ($error == null): true

--- a/e2e/test/lb-fw-delete-acl/chainsaw-test.yaml
+++ b/e2e/test/lb-fw-delete-acl/chainsaw-test.yaml
@@ -99,8 +99,6 @@ spec:
                   -H "accept: application/json" \
                   "$LINODE_URL/v4/networking/firewalls/${fwid}" || true)
 
-                echo "attempt $i: fwCount=$fwCount fwRespCode=$fwRespCode"
-
                 if [[ $fwCount -eq 0 && $fwRespCode -eq "404" ]]; then
                     echo "firewall detatched and deleted"
                     break

--- a/e2e/test/lb-fw-delete-acl/chainsaw-test.yaml
+++ b/e2e/test/lb-fw-delete-acl/chainsaw-test.yaml
@@ -65,6 +65,7 @@ spec:
     - name: Delete ACL and check that firewall no longer exists
       try:
         - script:
+            timeout: 5m
             content: |
               set -euo pipefail
 
@@ -81,7 +82,7 @@ spec:
               # Patch service to remove ACL annotation
               kubectl patch service svc-test -n $NAMESPACE --type=json -p='[{"op": "remove", "path": "/metadata/annotations/service.beta.kubernetes.io~1linode-loadbalancer-firewall-acl"}]'
 
-              for i in {1..10}; do
+              for i in {1..30}; do
                 # Check that firewall is no longer attached to nb
                 fw=$(curl -s --request GET \
                   -H "Authorization: Bearer $LINODE_TOKEN" \
@@ -97,6 +98,8 @@ spec:
                   -H "Authorization: Bearer $LINODE_TOKEN" \
                   -H "accept: application/json" \
                   "$LINODE_URL/v4/networking/firewalls/${fwid}" || true)
+
+                echo "attempt $i: fwCount=$fwCount fwRespCode=$fwRespCode"
 
                 if [[ $fwCount -eq 0 && $fwRespCode -eq "404" ]]; then
                     echo "firewall detatched and deleted"

--- a/e2e/test/lb-fw-delete-acl/chainsaw-test.yaml
+++ b/e2e/test/lb-fw-delete-acl/chainsaw-test.yaml
@@ -68,42 +68,41 @@ spec:
             content: |
               set -euo pipefail
 
+              nbid=$(KUBECONFIG=$KUBECONFIG NAMESPACE=$NAMESPACE LINODE_TOKEN=$LINODE_TOKEN ../scripts/get-nb-id.sh)
+
+              fw=$(curl -s --request GET \
+                -H "Authorization: Bearer $LINODE_TOKEN" \
+                -H "Content-Type: application/json" --fail-early --retry 3 \
+                -H "accept: application/json" \
+                "$LINODE_URL/v4/nodebalancers/${nbid}/firewalls" || true)
+
+              fwid=$(echo $fw | jq -r '.data[].id')
+
+              # Patch service to remove ACL annotation
+              kubectl patch service svc-test -n $NAMESPACE --type=json -p='[{"op": "remove", "path": "/metadata/annotations/service.beta.kubernetes.io~1linode-loadbalancer-firewall-acl"}]'
+
               for i in {1..10}; do
-                  nbid=$(KUBECONFIG=$KUBECONFIG NAMESPACE=$NAMESPACE LINODE_TOKEN=$LINODE_TOKEN ../scripts/get-nb-id.sh)
+                # Check that firewall is no longer attached to nb
+                fw=$(curl -s --request GET \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" --fail-early --retry 3 \
+                  -H "accept: application/json" \
+                  "$LINODE_URL/v4/nodebalancers/${nbid}/firewalls" || true)
 
-                  fw=$(curl -s --request GET \
-                    -H "Authorization: Bearer $LINODE_TOKEN" \
-                    -H "Content-Type: application/json" --fail-early --retry 3 \
-                    -H "accept: application/json" \
-                    "$LINODE_URL/v4/nodebalancers/${nbid}/firewalls" || true)
-                  
-                  fwid=$(echo $fw | jq -r '.data[].id')
+                fwCount=$(echo $fw | jq -r '.data | length')
 
-                  # Patch service to remove ACL annotation
-                  kubectl patch service svc-test -n $NAMESPACE --type=json -p='[{"op": "remove", "path": "/metadata/annotations/service.beta.kubernetes.io~1linode-loadbalancer-firewall-acl"}]'
-                  sleep 5
+                # Check if firewall is deleted
+                fwRespCode=$(curl -s -o /dev/null -w "%{http_code}" \
+                  --request GET \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "accept: application/json" \
+                  "$LINODE_URL/v4/networking/firewalls/${fwid}" || true)
 
-                  # Check that firewall is no longer attached to nb
-                  fw=$(curl -s --request GET \
-                    -H "Authorization: Bearer $LINODE_TOKEN" \
-                    -H "Content-Type: application/json" --fail-early --retry 3 \
-                    -H "accept: application/json" \
-                    "$LINODE_URL/v4/nodebalancers/${nbid}/firewalls" || true)
-                  
-                  fwCount=$(echo $fw | jq -r '.data | length')
-
-                  # Check if firewall is deleted
-                  fwRespCode=$(curl -s -o /dev/null -w "%{http_code}" \
-                    --request GET \
-                    -H "Authorization: Bearer $LINODE_TOKEN" \
-                    -H "accept: application/json" \
-                    "$LINODE_URL/v4/networking/firewalls/${fwid}" || true)
-
-                  if [[ $fwCount -eq 0 && $fwRespCode -eq "404" ]]; then
-                      echo "firewall detatched and deleted"
-                      break
-                  fi
-                  sleep 10
+                if [[ $fwCount -eq 0 && $fwRespCode -eq "404" ]]; then
+                    echo "firewall detatched and deleted"
+                    break
+                fi
+                sleep 10
               done
             check:
                 ($error == null): true

--- a/e2e/test/lb-update-port/chainsaw-test.yaml
+++ b/e2e/test/lb-update-port/chainsaw-test.yaml
@@ -41,12 +41,11 @@ spec:
         - script:
             content: |
               set -euo pipefail
-              sleep 30
               IP=$(kubectl get svc svc-test -n $NAMESPACE -o json | jq -r .status.loadBalancer.ingress[0].ip)
 
               podnames=()
 
-              for i in {1..10}; do
+              for i in {1..20}; do
                   if [[ ${#podnames[@]} -lt 2 ]]; then
                       output=$(curl -s $IP:80 | jq -e .podName || true)
 
@@ -86,12 +85,11 @@ spec:
             content: |
               set -euo pipefail
               #wait for changes to propagate to the LB
-              sleep 60
               IP=$(kubectl get svc svc-test -n $NAMESPACE -o json | jq -r .status.loadBalancer.ingress[0].ip)
 
               podnames=()
 
-              for i in {1..20}; do
+              for i in {1..30}; do
                   if [[ ${#podnames[@]} -lt 2 ]]; then
                       output=$(curl -s $IP:8080 | jq -e .podName || true)
 

--- a/e2e/test/lb-with-http-to-https/chainsaw-test.yaml
+++ b/e2e/test/lb-with-http-to-https/chainsaw-test.yaml
@@ -41,7 +41,6 @@ spec:
               set -euo pipefail
               kubectl annotate svc svc-test -n $NAMESPACE service.beta.kubernetes.io/linode-loadbalancer-port-443='{"tls-secret-name": "tls-secret-1", "protocol": "https"}'
               kubectl patch svc svc-test -n $NAMESPACE --type='json' -p='[{"op": "add", "path": "/spec/ports/-", "value": {"name": "https", "port": 443, "targetPort": 8080, "protocol": "TCP"}}]'
-              sleep 10
             check:
               ($error == null): true
     - name: Check endpoints

--- a/e2e/test/lb-with-http-to-https/chainsaw-test.yaml
+++ b/e2e/test/lb-with-http-to-https/chainsaw-test.yaml
@@ -43,7 +43,7 @@ spec:
               kubectl patch svc svc-test -n $NAMESPACE --type='json' -p='[{"op": "add", "path": "/spec/ports/-", "value": {"name": "https", "port": 443, "targetPort": 8080, "protocol": "TCP"}}]'
             check:
               ($error == null): true
-    - name: Check endpoints
+    - name: Check endpoints have addresses
       try:
       - assert:
           resource:
@@ -53,7 +53,6 @@ spec:
               name: svc-test
             (subsets[0].addresses != null): true
             (subsets[0].ports != null): true
-            (length(subsets[0].ports)): 2
       catch:
         - describe:
             apiVersion: v1
@@ -61,6 +60,15 @@ spec:
         - describe:
             apiVersion: v1
             kind: Service
+    - name: Check endpoints have two ports
+      try:
+      - assert:
+          resource:
+            apiVersion: v1
+            kind: Endpoints
+            metadata:
+              name: svc-test
+            (length(subsets[0].ports)): 2
     - name: Check that loadbalancer ip is assigned
       try:
       - assert:

--- a/e2e/test/lb-with-node-addition/chainsaw-test.yaml
+++ b/e2e/test/lb-with-node-addition/chainsaw-test.yaml
@@ -82,6 +82,8 @@ spec:
               required_replicas=$((current_replicas + 1))
               KUBECONFIG=$MGMT_KUBECONFIG kubectl patch machinedeployment ${CLUSTER_NAME}-md-0 --type='merge' -p "{\"spec\":{\"replicas\":$required_replicas}}"
 
+              sleep 180
+
               nbid=$(KUBECONFIG=$KUBECONFIG NAMESPACE=$NAMESPACE LINODE_TOKEN=$LINODE_TOKEN ../scripts/get-nb-id.sh)
               echo "Nodebalancer ID: $nbid"
 

--- a/e2e/test/lb-with-node-addition/chainsaw-test.yaml
+++ b/e2e/test/lb-with-node-addition/chainsaw-test.yaml
@@ -82,12 +82,10 @@ spec:
               required_replicas=$((current_replicas + 1))
               KUBECONFIG=$MGMT_KUBECONFIG kubectl patch machinedeployment ${CLUSTER_NAME}-md-0 --type='merge' -p "{\"spec\":{\"replicas\":$required_replicas}}"
 
-              sleep 180
-
               nbid=$(KUBECONFIG=$KUBECONFIG NAMESPACE=$NAMESPACE LINODE_TOKEN=$LINODE_TOKEN ../scripts/get-nb-id.sh)
               echo "Nodebalancer ID: $nbid"
 
-              for i in {1..20}; do
+              for i in {1..30}; do
                   response=$(curl -sf \
                     -H "Authorization: Bearer $LINODE_TOKEN" \
                     -H "Content-Type: application/json" --fail-early --retry 3 \

--- a/e2e/test/lb-with-proxyprotocol-default-annotation/chainsaw-test.yaml
+++ b/e2e/test/lb-with-proxyprotocol-default-annotation/chainsaw-test.yaml
@@ -42,7 +42,6 @@ spec:
             content: |
               set -euo pipefail
               kubectl annotate svc svc-test -n $NAMESPACE service.beta.kubernetes.io/linode-loadbalancer-proxy-protocol=v2
-              sleep 10
             check:
               ($error == null): true
     - name: Check NodeBalancerConfig for port 80 and 8080 have ProxyProtocol v2
@@ -79,7 +78,6 @@ spec:
             content: |
               set -euo pipefail
               kubectl annotate svc svc-test -n $NAMESPACE service.beta.kubernetes.io/linode-loadbalancer-default-proxy-protocol=v1
-              sleep 10
             check:
               ($error == null): true
     - name: Check NodeBalancerConfig for port 80 and 8080 have ProxyProtocol v1
@@ -88,34 +86,25 @@ spec:
             content: |
               set -euo pipefail
 
-              re='^[0-9]+$'
+              nbid=$(KUBECONFIG=$KUBECONFIG NAMESPACE=$NAMESPACE LINODE_TOKEN=$LINODE_TOKEN ../scripts/get-nb-id.sh)
 
-              hostname=$(kubectl get svc svc-test -n $NAMESPACE -o json | jq -r .status.loadBalancer.ingress[0].hostname)
-              ip=$(echo $hostname | awk -F'.' '{gsub("-", ".", $1); print $1}')
-              nbid=$(curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" --fail-early --retry 3 \
-                -H "X-Filter: {\"ipv4\": \"$ip\"}" \
-                "$LINODE_URL/v4/nodebalancers"  | jq .data[].id)
+              for i in {1..10}; do
+                nbconfig=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" --fail-early --retry 3 \
+                  "$LINODE_URL/v4/nodebalancers/$nbid/configs")
 
-              if ! [[ $nbid =~ $re ]]; then
-                  echo "Nodebalancer id [$nbid] is incorrect, doesn't meet regex requirements"
-                  exit 1
-              fi
+                port_80_v1=$(echo $nbconfig | jq -r '.data[] | select(.port == 80) | .proxy_protocol == "v1"')
+                port_8080_v1=$(echo $nbconfig | jq -r '.data[] | select(.port == 8080) | .proxy_protocol == "v1"')
 
-              nbconfig=$(curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" --fail-early --retry 3 \
-                "$LINODE_URL/v4/nodebalancers/$nbid/configs")
-
-              port_80_v1=$(echo $nbconfig | jq -r '.data[] | select(.port == 80) | .proxy_protocol == "v1"')
-              port_8080_v1=$(echo $nbconfig | jq -r '.data[] | select(.port == 8080) | .proxy_protocol == "v1"')
-
-              if [[ $port_80_v1 == "true" && $port_8080_v1 == "true" ]]; then
-                  echo "Conditions met"
-              else
-                  echo "Conditions not met"
-              fi
+                if [[ $port_80_v1 == "true" && $port_8080_v1 == "true" ]]; then
+                    echo "Conditions met"
+                    break
+                else
+                    echo "Conditions not met"
+                fi
+                sleep 10
+              done
             check:
               ($error): ~
               (contains($stdout, 'Conditions met')): true

--- a/e2e/test/lb-with-proxyprotocol-override/chainsaw-test.yaml
+++ b/e2e/test/lb-with-proxyprotocol-override/chainsaw-test.yaml
@@ -36,6 +36,16 @@ spec:
               name: svc-test
             (subsets[0].addresses != null): true
             (subsets[0].ports != null): true
+    - name: Check that loadbalancer ip is assigned
+      try:
+      - assert:
+          resource:
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: svc-test
+            status:
+              (loadBalancer.ingress[0].ip != null): true
     - name: Annotate service port 80 with v1 and 8080 with v2
       try:
         - script:

--- a/e2e/test/lb-with-proxyprotocol-port-specific/chainsaw-test.yaml
+++ b/e2e/test/lb-with-proxyprotocol-port-specific/chainsaw-test.yaml
@@ -42,7 +42,6 @@ spec:
             content: |
               set -euo pipefail
               kubectl annotate svc svc-test -n $NAMESPACE service.beta.kubernetes.io/linode-loadbalancer-port-8080='{"proxy-protocol": "v2"}'
-              sleep 10
             check:
               ($error == null): true
     - name: Check NodeBalancerConfig for port 80 to not have ProxyProtocol and port 8080 to have ProxyProtocol v2
@@ -53,19 +52,23 @@ spec:
 
               nbid=$(KUBECONFIG=$KUBECONFIG NAMESPACE=$NAMESPACE LINODE_TOKEN=$LINODE_TOKEN ../scripts/get-nb-id.sh)
 
-              nbconfig=$(curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" --fail-early --retry 3 \
-                "$LINODE_URL/v4/nodebalancers/$nbid/configs")
+              for i in {1..10}; do
+                nbconfig=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" --fail-early --retry 3 \
+                  "$LINODE_URL/v4/nodebalancers/$nbid/configs")
 
-              port_80_none=$(echo $nbconfig | jq -r '.data[] | select(.port == 80) | .proxy_protocol == "none"')
-              port_8080_v2=$(echo $nbconfig | jq -r '.data[] | select(.port == 8080) | .proxy_protocol == "v2"')
+                port_80_none=$(echo $nbconfig | jq -r '.data[] | select(.port == 80) | .proxy_protocol == "none"')
+                port_8080_v2=$(echo $nbconfig | jq -r '.data[] | select(.port == 8080) | .proxy_protocol == "v2"')
 
-              if [[ $port_80_none == "true" && $port_8080_v2 == "true" ]]; then
-                  echo "Conditions met"
-              else
-                  echo "Conditions not met"
-              fi
+                if [[ $port_80_none == "true" && $port_8080_v2 == "true" ]]; then
+                    echo "Conditions met"
+                    break
+                else
+                    echo "Conditions not met"
+                fi
+                sleep 10
+              done
             check:
               ($error): ~
               (contains($stdout, 'Conditions met')): true

--- a/e2e/test/lb-with-proxyprotocol-port-specific/chainsaw-test.yaml
+++ b/e2e/test/lb-with-proxyprotocol-port-specific/chainsaw-test.yaml
@@ -36,6 +36,16 @@ spec:
               name: svc-test
             (subsets[0].addresses != null): true
             (subsets[0].ports != null): true
+    - name: Check that loadbalancer ip is assigned
+      try:
+      - assert:
+          resource:
+            apiVersion: v1
+            kind: Service
+            metadata:
+              name: svc-test
+            status:
+              (loadBalancer.ingress[0].ip != null): true
     - name: Annotate service port 80 with v1 and 8080 with v2
       try:
         - script:

--- a/e2e/test/lb-with-proxyprotocol-set/chainsaw-test.yaml
+++ b/e2e/test/lb-with-proxyprotocol-set/chainsaw-test.yaml
@@ -53,7 +53,6 @@ spec:
               set -euo pipefail
               kubectl annotate svc svc-test -n $NAMESPACE service.beta.kubernetes.io/linode-loadbalancer-port-80='{"proxy-protocol": "v1"}'
               kubectl annotate svc svc-test -n $NAMESPACE service.beta.kubernetes.io/linode-loadbalancer-port-8080='{"proxy-protocol": "v2"}'
-              sleep 10
             check:
               ($error == null): true
     - name: Check NodeBalancerConfig for port 80 to have ProxyProtocol v1 and port 8080 to have ProxyProtocol v2
@@ -64,19 +63,23 @@ spec:
 
               nbid=$(KUBECONFIG=$KUBECONFIG NAMESPACE=$NAMESPACE LINODE_TOKEN=$LINODE_TOKEN ../scripts/get-nb-id.sh)
 
-              nbconfig=$(curl -s \
-                -H "Authorization: Bearer $LINODE_TOKEN" \
-                -H "Content-Type: application/json" --fail-early --retry 3 \
-                "$LINODE_URL/v4/nodebalancers/$nbid/configs")
+              for i in {1..10}; do
+                nbconfig=$(curl -s \
+                  -H "Authorization: Bearer $LINODE_TOKEN" \
+                  -H "Content-Type: application/json" --fail-early --retry 3 \
+                  "$LINODE_URL/v4/nodebalancers/$nbid/configs")
 
-              port_80_v1=$(echo $nbconfig | jq -r '.data[] | select(.port == 80) | .proxy_protocol == "v1"')
-              port_8080_v2=$(echo $nbconfig | jq -r '.data[] | select(.port == 8080) | .proxy_protocol == "v2"')
+                port_80_v1=$(echo $nbconfig | jq -r '.data[] | select(.port == 80) | .proxy_protocol == "v1"')
+                port_8080_v2=$(echo $nbconfig | jq -r '.data[] | select(.port == 8080) | .proxy_protocol == "v2"')
 
-              if [[ $port_80_v1 == "true" && $port_8080_v2 == "true" ]]; then
-                  echo "Conditions met"
-              else
-                  echo "Conditions not met"
-              fi
+                if [[ $port_80_v1 == "true" && $port_8080_v2 == "true" ]]; then
+                    echo "Conditions met"
+                    break
+                else
+                    echo "Conditions not met"
+                fi
+                sleep 10
+              done
             check:
               ($error): ~
               (contains($stdout, 'Conditions met')): true

--- a/e2e/test/lb-with-udp-ports-algorithm/chainsaw-test.yaml
+++ b/e2e/test/lb-with-udp-ports-algorithm/chainsaw-test.yaml
@@ -53,12 +53,17 @@ spec:
               echo "Nodebalancer config found, updating config algorithm"
 
               kubectl annotate --overwrite svc svc-test -n $NAMESPACE service.beta.kubernetes.io/linode-loadbalancer-default-algorithm=ring_hash
-              sleep 5s
- 
+
               echo "Verifying that algorithm is set to ring hash"
-              nbconfig=$(LINODE_TOKEN=$LINODE_TOKEN NBID=$nbid ../scripts/get-nb-config.sh)
-              algorithm=$(echo $nbconfig | jq -r '.algorithm')
-              echo "algorithm is $algorithm"
+              for i in {1..10}; do
+                nbconfig=$(LINODE_TOKEN=$LINODE_TOKEN NBID=$nbid ../scripts/get-nb-config.sh)
+                algorithm=$(echo $nbconfig | jq -r '.algorithm')
+                echo "algorithm is $algorithm"
+                if [[ "$algorithm" == "ring_hash" ]]; then
+                  break
+                fi
+                sleep 10
+              done
             check:
               ($error == null): true
               (contains($stdout, 'algorithm is ring_hash')): true


### PR DESCRIPTION
## What

- Fix `get-nb-id.sh` to read the NodeBalancer IP directly from `status.loadBalancer.ingress[0].ip` instead of parsing it from the service hostname DNS label, which was brittle and caused widespread test failures.

- Replace hard `sleep` + one-shot checks with polling loops (`for i in {1..N}; do ... sleep 10; done`) across 15+ tests. Hard sleeps either fail when the system is slow or waste time when it's fast.

- Fix the old hostname-based NB ID lookup in
  `lb-with-proxyprotocol-default-annotation` (same root cause as `get-nb-id.sh`).

- Fix `name: c` typo in `lb-created-with-reserved-ip-multiple-change-ip`.

- Remove `sleep 180` in `lb-with-node-addition` before the node provisioning poll; extend the loop from 20→30 iterations to keep the same ~10m budget without a blind wait.

## Why

These tests were flaky on timing, not because of real CCM bugs. The polling pattern is already established in the codebase. This PR applies it consistently.

Signed-off-by: Moshe Vayner <moshe@vayner.me>
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:

* [ ] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [ ] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [ ] Does your submission pass tests?
1. [ ] Have you added tests? 
1. [ ] Are you addressing a single feature in this PR? 
1. [ ] Are your commits atomic, addressing one change per commit?
1. [ ] Are you following the conventions of the language? 
1. [ ] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [ ] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

