### PR TITLE
Bugfix: VPC api call failures could cause deletion of all nodes

### DIFF
--- a/cloud/linode/services/instances.go
+++ b/cloud/linode/services/instances.go
@@ -103,8 +103,7 @@ func (nc *nodeCache) refreshInstances(ctx context.Context, client client.Client)
 		}
 		resp, err := GetVPCIPAddresses(ctx, client, vpcName)
 		if err != nil {
-			klog.Errorf("failed updating instances cache for VPC %s. Error: %s", vpcName, err.Error())
-			continue
+			return fmt.Errorf("failed updating instances cache for VPC %s: %w", vpcName, err)
 		}
 		for _, vpcip := range resp {
 			if vpcip.Address == nil {
@@ -115,8 +114,7 @@ func (nc *nodeCache) refreshInstances(ctx context.Context, client client.Client)
 
 		resp, err = GetVPCIPv6Addresses(ctx, client, vpcName)
 		if err != nil {
-			klog.Errorf("failed updating instances cache for VPC %s. Error: %s", vpcName, err.Error())
-			continue
+			return fmt.Errorf("failed updating instances cache for VPC %s: %w", vpcName, err)
 		}
 		for _, vpcip := range resp {
 			if len(vpcip.IPv6Addresses) == 0 {

--- a/cloud/linode/services/instances_test.go
+++ b/cloud/linode/services/instances_test.go
@@ -456,6 +456,116 @@ func TestMalformedProviders(t *testing.T) {
 	})
 }
 
+func TestRefreshInstancesVPCErrors(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c := mocks.NewMockClient(ctrl)
+
+	t.Run("returns error when GetVPCIPAddresses fails", func(t *testing.T) {
+		instances := NewInstances(c)
+		node := nodeWithProviderID(ccmUtils.ProviderIDPrefix + "123")
+
+		options.Options.VPCNames = []string{"test"}
+		VpcIDs["test"] = 1
+		defer func() {
+			options.Options.VPCNames = []string{}
+			delete(VpcIDs, "test")
+		}()
+
+		apiErr := fmt.Errorf("VPC API error")
+		c.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
+			{ID: 123, Label: "test-instance"},
+		}, nil)
+		c.EXPECT().ListVPCIPAddresses(gomock.Any(), 1, gomock.Any()).Return(nil, apiErr)
+
+		_, err := instances.InstanceExists(ctx, node)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed updating instances cache for VPC test")
+	})
+
+	t.Run("returns error when GetVPCIPv6Addresses fails", func(t *testing.T) {
+		instances := NewInstances(c)
+		node := nodeWithProviderID(ccmUtils.ProviderIDPrefix + "123")
+
+		options.Options.VPCNames = []string{"test"}
+		VpcIDs["test"] = 1
+		defer func() {
+			options.Options.VPCNames = []string{}
+			delete(VpcIDs, "test")
+		}()
+
+		vpcIP := "10.0.0.2"
+		apiErr := fmt.Errorf("VPC IPv6 API error")
+		c.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
+			{ID: 123, Label: "test-instance"},
+		}, nil)
+		c.EXPECT().ListVPCIPAddresses(gomock.Any(), 1, gomock.Any()).Return([]linodego.VPCIP{
+			{Address: &vpcIP, LinodeID: 123, VPCID: 1},
+		}, nil)
+		c.EXPECT().ListVPCIPv6Addresses(gomock.Any(), 1, gomock.Any()).Return(nil, apiErr)
+
+		_, err := instances.InstanceExists(ctx, node)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed updating instances cache for VPC test")
+	})
+
+	t.Run("does not update cache when GetVPCIPAddresses fails", func(t *testing.T) {
+		instances := NewInstances(c)
+		node := nodeWithProviderID(ccmUtils.ProviderIDPrefix + "123")
+
+		options.Options.VPCNames = []string{"test"}
+		VpcIDs["test"] = 1
+		defer func() {
+			options.Options.VPCNames = []string{}
+			delete(VpcIDs, "test")
+		}()
+
+		apiErr := fmt.Errorf("VPC API error")
+		c.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
+			{ID: 123, Label: "test-instance"},
+		}, nil)
+		c.EXPECT().ListVPCIPAddresses(gomock.Any(), 1, gomock.Any()).Return(nil, apiErr)
+
+		_, err := instances.InstanceExists(ctx, node)
+		require.Error(t, err)
+
+		// Cache must not be stamped so the next call retries instead of
+		// serving the empty/stale data that caused the original node-deletion bug.
+		assert.True(t, instances.nodeCache.lastUpdate.IsZero(), "cache lastUpdate should remain zero after a failed refresh")
+	})
+
+	t.Run("does not update cache when GetVPCIPv6Addresses fails", func(t *testing.T) {
+		instances := NewInstances(c)
+		node := nodeWithProviderID(ccmUtils.ProviderIDPrefix + "123")
+
+		options.Options.VPCNames = []string{"test"}
+		VpcIDs["test"] = 1
+		defer func() {
+			options.Options.VPCNames = []string{}
+			delete(VpcIDs, "test")
+		}()
+
+		vpcIP := "10.0.0.2"
+		apiErr := fmt.Errorf("VPC IPv6 API error")
+		c.EXPECT().ListInstances(gomock.Any(), nil).Times(1).Return([]linodego.Instance{
+			{ID: 123, Label: "test-instance"},
+		}, nil)
+		c.EXPECT().ListVPCIPAddresses(gomock.Any(), 1, gomock.Any()).Return([]linodego.VPCIP{
+			{Address: &vpcIP, LinodeID: 123, VPCID: 1},
+		}, nil)
+		c.EXPECT().ListVPCIPv6Addresses(gomock.Any(), 1, gomock.Any()).Return(nil, apiErr)
+
+		_, err := instances.InstanceExists(ctx, node)
+		require.Error(t, err)
+
+		// Cache must not be stamped so the next call retries instead of
+		// serving the empty/stale data that caused the original node-deletion bug.
+		assert.True(t, instances.nodeCache.lastUpdate.IsZero(), "cache lastUpdate should remain zero after a failed refresh")
+	})
+}
+
 func TestInstanceShutdown(t *testing.T) {
 	ctx := t.Context()
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->

Hello, I was trying find a bug in cooperation between linode LKE api provider and linode CCM to explain unexpected behavior which I have seen on few clusters. I'm not sure I found the root cause of the issue I was observing, but I do believe I have found at least related one.

Here's the possible failure chain:

1.  GetVPCIPAddresses or GetVPCIPv6Addresses returns error, that error would only be logged but the node will be skipped on writing to cache, due to condition:

```
if len(options.Options.VPCNames) > 0 && len(vpcNodes[instance.ID]) == 0 {
    continue  // instance skipped — vpcNodes is empty due to the failed API call
}
```

2.  InstanceExists returns false, nil for every node, because linodeByID finds nothing in the empty cache and returns cloudprovider.InstanceNotFound which InstanceExists converts to false, nil.

3. The cache is written with an empty map and `lastUpdate` is stamped `nc.nodes = newNodes; nc.lastUpdate = time.Now()`, so the bad data persists for the full TTL period (default 15s).

4. The K8s node lifecycle controller deletes such nodes.

### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [n] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [n] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

