### PR TITLE
[improvement] address cyclop issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - containedctx
     - contextcheck
     - copyloopvar
+    - cyclop
     - decorder
     - depguard
     - dogsled
@@ -133,6 +134,7 @@ linters:
     rules:
       - linters:
           - copyloopvar
+          - cyclop
           - dupl
           - errcheck
           - gocognit

--- a/cloud/linode/cloud.go
+++ b/cloud/linode/cloud.go
@@ -176,73 +176,64 @@ func tokenProviderFromFileOrEnv() (client.TokenProvider, string, error) {
 	return nil, "", fmt.Errorf("failed to load linode api token from %s=%q: %w; fallback %s is not set", tokenFilePathEnv, tokenFilePath, fileErr, accessTokenEnv)
 }
 
-func newCloud() (cloudprovider.Interface, error) {
-	region := os.Getenv(regionEnv)
-	if region == "" {
-		return nil, fmt.Errorf("%s must be set in the environment (use a k8s secret)", regionEnv)
-	}
-
-	tokenProvider, tokenSourceDescription, err := tokenProviderFromFileOrEnv()
-	if err != nil {
-		return nil, err
-	}
-
-	// set timeout used by linodeclient for API calls
+// requestTimeoutFromEnv resolves the client timeout used for Linode API calls,
+// honoring LINODE_REQUEST_TIMEOUT_SECONDS if set to a valid positive integer.
+func requestTimeoutFromEnv() time.Duration {
 	timeout := client.DefaultClientTimeout
 	if raw, ok := os.LookupEnv("LINODE_REQUEST_TIMEOUT_SECONDS"); ok {
 		if t, atoiErr := strconv.Atoi(raw); atoiErr == nil && t > 0 {
 			timeout = time.Duration(t) * time.Second
 		}
 	}
+	return timeout
+}
 
-	linodeClient, err := newLinodeClientWithPrometheus(timeout, tokenProvider)
+// setupTokenHealthChecker validates the Linode API token (when enabled) and
+// returns a healthChecker to be run by the cloud provider, if applicable.
+func setupTokenHealthChecker(linodeClient client.Client, tokenSourceDescription string) (*healthChecker, error) {
+	if !options.Options.EnableTokenHealthChecker {
+		return nil, nil //nolint:nilnil // nil, nil indicates the health checker is disabled, not an error
+	}
+
+	authenticated, err := client.CheckClientAuthenticated(context.TODO(), linodeClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("linode client authenticated connection error: %w", err)
 	}
 
-	var healthChecker *healthChecker
-
-	if options.Options.EnableTokenHealthChecker {
-		var authenticated bool
-		authenticated, err = client.CheckClientAuthenticated(context.TODO(), linodeClient)
-		if err != nil {
-			return nil, fmt.Errorf("linode client authenticated connection error: %w", err)
-		}
-
-		if !authenticated {
-			return nil, fmt.Errorf("linode api token from %s is invalid", tokenSourceDescription)
-		}
-
-		healthChecker = newHealthChecker(linodeClient, tokenHealthCheckPeriod, options.Options.GlobalStopChannel)
+	if !authenticated {
+		return nil, fmt.Errorf("linode api token from %s is invalid", tokenSourceDescription)
 	}
 
-	err = services.ValidateAndSetVPCSubnetFlags(linodeClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to validate VPC and subnet flags: %w", err)
-	}
+	return newHealthChecker(linodeClient, tokenHealthCheckPeriod, options.Options.GlobalStopChannel), nil
+}
 
+// setupNodeBalancerBackendSubnet resolves and validates the NodeBalancer
+// backend IPv4 subnet options, mutating options.Options as needed.
+func setupNodeBalancerBackendSubnet(linodeClient client.Client) error {
 	if options.Options.NodeBalancerBackendIPv4SubnetID != 0 && options.Options.NodeBalancerBackendIPv4SubnetName != "" {
-		return nil, fmt.Errorf("cannot have both --nodebalancer-backend-ipv4-subnet-id and --nodebalancer-backend-ipv4-subnet-name set")
+		return fmt.Errorf("cannot have both --nodebalancer-backend-ipv4-subnet-id and --nodebalancer-backend-ipv4-subnet-name set")
 	}
 
-	if options.Options.DisableNodeBalancerVPCBackends {
+	switch {
+	case options.Options.DisableNodeBalancerVPCBackends:
 		klog.Infof("NodeBalancer VPC backends are disabled, no VPC backends will be created for NodeBalancers")
 		options.Options.NodeBalancerBackendIPv4SubnetID = 0
 		options.Options.NodeBalancerBackendIPv4SubnetName = ""
-	} else if options.Options.NodeBalancerBackendIPv4SubnetName != "" {
-		options.Options.NodeBalancerBackendIPv4SubnetID, err = services.GetNodeBalancerBackendIPv4SubnetID(linodeClient)
+	case options.Options.NodeBalancerBackendIPv4SubnetName != "":
+		subnetID, err := services.GetNodeBalancerBackendIPv4SubnetID(linodeClient)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get backend IPv4 subnet ID for subnet name %s: %w", options.Options.NodeBalancerBackendIPv4SubnetName, err)
+			return fmt.Errorf("failed to get backend IPv4 subnet ID for subnet name %s: %w", options.Options.NodeBalancerBackendIPv4SubnetName, err)
 		}
+		options.Options.NodeBalancerBackendIPv4SubnetID = subnetID
 		klog.Infof("Using NodeBalancer backend IPv4 subnet ID %d for subnet name %s", options.Options.NodeBalancerBackendIPv4SubnetID, options.Options.NodeBalancerBackendIPv4SubnetName)
 	}
 
-	instanceCache = services.NewInstances(linodeClient)
-	routes, err := newRoutes(linodeClient, instanceCache)
-	if err != nil {
-		return nil, fmt.Errorf("routes client was not created successfully: %w", err)
-	}
+	return nil
+}
 
+// applyDeprecatedOptionWarnings logs warnings for, and normalizes, deprecated
+// CLI options that are retained only for backwards compatibility.
+func applyDeprecatedOptionWarnings() {
 	if options.Options.LoadBalancerType == ciliumLBType {
 		klog.Warningf("--load-balancer-type=%s is deprecated and has no effect; using %s", ciliumLBType, nodeBalancerLBType)
 		options.Options.LoadBalancerType = nodeBalancerLBType
@@ -255,9 +246,13 @@ func newCloud() (cloudprovider.Interface, error) {
 	if options.Options.IpHolderSuffix != "" {
 		klog.Warning("--ip-holder-suffix is deprecated and has no effect; it is retained for backwards compatibility")
 	}
+}
 
+// validateNodeBalancerOptions validates the configured load-balancer type and
+// NodeBalancer prefix options.
+func validateNodeBalancerOptions() error {
 	if options.Options.LoadBalancerType != "" && !slices.Contains(supportedLoadBalancerTypes, options.Options.LoadBalancerType) {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"unsupported default load-balancer type %s. options.Options are %v",
 			options.Options.LoadBalancerType,
 			supportedLoadBalancerTypes,
@@ -267,14 +262,58 @@ func newCloud() (cloudprovider.Interface, error) {
 	if len(options.Options.NodeBalancerPrefix) > NodeBalancerPrefixCharLimit {
 		msg := fmt.Sprintf("nodebalancer-prefix must be %d characters or less: %s is %d characters\n", NodeBalancerPrefixCharLimit, options.Options.NodeBalancerPrefix, len(options.Options.NodeBalancerPrefix))
 		klog.Error(msg)
-		return nil, fmt.Errorf("%s", msg)
+		return fmt.Errorf("%s", msg)
 	}
 
 	validPrefix := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 	if !validPrefix.MatchString(options.Options.NodeBalancerPrefix) {
 		msg := fmt.Sprintf("nodebalancer-prefix must be no empty and use only letters, numbers, underscores, and dashes: %s\n", options.Options.NodeBalancerPrefix)
 		klog.Error(msg)
-		return nil, fmt.Errorf("%s", msg)
+		return fmt.Errorf("%s", msg)
+	}
+
+	return nil
+}
+
+func newCloud() (cloudprovider.Interface, error) {
+	region := os.Getenv(regionEnv)
+	if region == "" {
+		return nil, fmt.Errorf("%s must be set in the environment (use a k8s secret)", regionEnv)
+	}
+
+	tokenProvider, tokenSourceDescription, err := tokenProviderFromFileOrEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	linodeClient, err := newLinodeClientWithPrometheus(requestTimeoutFromEnv(), tokenProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	healthChecker, err := setupTokenHealthChecker(linodeClient, tokenSourceDescription)
+	if err != nil {
+		return nil, err
+	}
+
+	if vpcErr := services.ValidateAndSetVPCSubnetFlags(linodeClient); vpcErr != nil {
+		return nil, fmt.Errorf("failed to validate VPC and subnet flags: %w", vpcErr)
+	}
+
+	if subnetErr := setupNodeBalancerBackendSubnet(linodeClient); subnetErr != nil {
+		return nil, subnetErr
+	}
+
+	instanceCache = services.NewInstances(linodeClient)
+	routes, err := newRoutes(linodeClient, instanceCache)
+	if err != nil {
+		return nil, fmt.Errorf("routes client was not created successfully: %w", err)
+	}
+
+	applyDeprecatedOptionWarnings()
+
+	if err := validateNodeBalancerOptions(); err != nil {
+		return nil, err
 	}
 
 	// create struct that satisfies cloudprovider.Interface

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -955,6 +955,76 @@ func (l *loadbalancers) createNodeBalancer(ctx context.Context, clusterName stri
 	return l.client.CreateNodeBalancer(ctx, createOpts)
 }
 
+// applyHealthCheckBody sets the config's health check path/body based on the
+// configured health check type, returning an error if a required annotation
+// is missing.
+func applyHealthCheckBody(service *v1.Service, health linodego.ConfigCheck, config *linodego.NodeBalancerConfig) error {
+	if health == linodego.CheckHTTP || health == linodego.CheckHTTPBody {
+		path := service.GetAnnotations()[annotations.AnnLinodeCheckPath]
+		if path == "" {
+			path = "/"
+		}
+		config.CheckPath = path
+	}
+
+	if health == linodego.CheckHTTPBody {
+		body := service.GetAnnotations()[annotations.AnnLinodeCheckBody]
+		if body == "" {
+			return fmt.Errorf("for health check type http_body need body regex annotation %v", annotations.AnnLinodeCheckBody)
+		}
+		config.CheckBody = body
+	}
+
+	return nil
+}
+
+// applyHealthCheckTuning sets the config's check interval, timeout, attempts,
+// and passive-check settings from the service annotations, falling back to
+// defaults when annotations are absent.
+func applyHealthCheckTuning(service *v1.Service, config *linodego.NodeBalancerConfig) error {
+	annotationsMap := service.GetAnnotations()
+
+	checkInterval := 5
+	if ci, ok := annotationsMap[annotations.AnnLinodeHealthCheckInterval]; ok {
+		var err error
+		if checkInterval, err = strconv.Atoi(ci); err != nil {
+			return err
+		}
+	}
+	config.CheckInterval = checkInterval
+
+	checkTimeout := 3
+	if ct, ok := annotationsMap[annotations.AnnLinodeHealthCheckTimeout]; ok {
+		var err error
+		if checkTimeout, err = strconv.Atoi(ct); err != nil {
+			return err
+		}
+	}
+	config.CheckTimeout = checkTimeout
+
+	checkAttempts := 2
+	if ca, ok := annotationsMap[annotations.AnnLinodeHealthCheckAttempts]; ok {
+		var err error
+		if checkAttempts, err = strconv.Atoi(ca); err != nil {
+			return err
+		}
+	}
+	config.CheckAttempts = checkAttempts
+
+	checkPassive := true
+	if config.Protocol == linodego.ProtocolUDP {
+		checkPassive = false
+	} else if cp, ok := annotationsMap[annotations.AnnLinodeHealthCheckPassive]; ok {
+		var err error
+		if checkPassive, err = strconv.ParseBool(cp); err != nil {
+			return err
+		}
+	}
+	config.CheckPassive = checkPassive
+
+	return nil
+}
+
 func (l *loadbalancers) buildNodeBalancerConfig(ctx context.Context, service *v1.Service, port v1.ServicePort) (linodego.NodeBalancerConfig, error) {
 	portConfigResult, err := getPortConfig(service, port)
 	if err != nil {
@@ -982,54 +1052,13 @@ func (l *loadbalancers) buildNodeBalancerConfig(ctx context.Context, service *v1
 		config.UDPCheckPort = portConfigResult.UDPCheckPort
 	}
 
-	if health == linodego.CheckHTTP || health == linodego.CheckHTTPBody {
-		path := service.GetAnnotations()[annotations.AnnLinodeCheckPath]
-		if path == "" {
-			path = "/"
-		}
-		config.CheckPath = path
+	if bodyErr := applyHealthCheckBody(service, health, &config); bodyErr != nil {
+		return config, bodyErr
 	}
 
-	if health == linodego.CheckHTTPBody {
-		body := service.GetAnnotations()[annotations.AnnLinodeCheckBody]
-		if body == "" {
-			return config, fmt.Errorf("for health check type http_body need body regex annotation %v", annotations.AnnLinodeCheckBody)
-		}
-		config.CheckBody = body
+	if tuningErr := applyHealthCheckTuning(service, &config); tuningErr != nil {
+		return config, tuningErr
 	}
-	checkInterval := 5
-	if ci, ok := service.GetAnnotations()[annotations.AnnLinodeHealthCheckInterval]; ok {
-		if checkInterval, err = strconv.Atoi(ci); err != nil {
-			return config, err
-		}
-	}
-	config.CheckInterval = checkInterval
-
-	checkTimeout := 3
-	if ct, ok := service.GetAnnotations()[annotations.AnnLinodeHealthCheckTimeout]; ok {
-		if checkTimeout, err = strconv.Atoi(ct); err != nil {
-			return config, err
-		}
-	}
-	config.CheckTimeout = checkTimeout
-
-	checkAttempts := 2
-	if ca, ok := service.GetAnnotations()[annotations.AnnLinodeHealthCheckAttempts]; ok {
-		if checkAttempts, err = strconv.Atoi(ca); err != nil {
-			return config, err
-		}
-	}
-	config.CheckAttempts = checkAttempts
-
-	checkPassive := true
-	if config.Protocol == linodego.ProtocolUDP {
-		checkPassive = false
-	} else if cp, ok := service.GetAnnotations()[annotations.AnnLinodeHealthCheckPassive]; ok {
-		if checkPassive, err = strconv.ParseBool(cp); err != nil {
-			return config, err
-		}
-	}
-	config.CheckPassive = checkPassive
 
 	if portConfigResult.Protocol == linodego.ProtocolHTTPS {
 		if err = l.addTLSCert(ctx, service, &config, portConfigResult); err != nil {

--- a/cloud/linode/node_controller.go
+++ b/cloud/linode/node_controller.go
@@ -266,15 +266,14 @@ func (s *nodeController) SetLastMetadataUpdate(nodeName string) {
 	s.metadataLastUpdate[nodeName] = time.Now()
 }
 
-func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
-	klog.V(3).InfoS("NodeController handling node metadata",
-		"node", klog.KObj(node))
-
+// metadataNeedsRefresh reports whether the node's cached metadata (UUID,
+// private IP, public IPv6 annotations) is stale and should be refreshed.
+func (s *nodeController) metadataNeedsRefresh(node *v1.Node) bool {
 	lastUpdate := s.LastMetadataUpdate(node.Name)
 
-	uuid, foundLabel := node.Labels[annotations.AnnLinodeHostUUID]
-	configuredPrivateIP, foundPrivateIPAnnotation := node.Annotations[annotations.AnnLinodeNodePrivateIP]
-	configuredPublicIPv6, foundIPv6Annotation := node.Annotations[annotations.AnnLinodeNodePublicIPv6]
+	_, foundLabel := node.Labels[annotations.AnnLinodeHostUUID]
+	_, foundPrivateIPAnnotation := node.Annotations[annotations.AnnLinodeNodePrivateIP]
+	_, foundIPv6Annotation := node.Annotations[annotations.AnnLinodeNodePublicIPv6]
 
 	metaAge := time.Since(lastUpdate)
 	if foundLabel && foundPrivateIPAnnotation && foundIPv6Annotation && metaAge < s.ttl {
@@ -283,33 +282,29 @@ func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
 			"ttl", s.ttl,
 			"metadata_age", metaAge,
 		)
-		return nil
+		return false
 	}
 
-	linode, err := s.instances.LookupLinode(ctx, node)
-	if err != nil {
-		klog.V(1).ErrorS(err, "Instance lookup error")
-		return err
-	}
+	return true
+}
 
-	expectedPrivateIP := ""
-	// linode API response for linode will contain only one private ip
-	// if any private ip is configured.
+// expectedPrivateIP returns the private IPv4 address for the linode, if any.
+// The Linode API response for an instance will contain only one private IP
+// if any private IP is configured.
+func expectedPrivateIP(linode *linodego.Instance) string {
 	for _, addr := range linode.IPv4 {
 		if ccmUtils.IsPrivate(addr, options.Options.LinodeExternalNetwork) {
-			expectedPrivateIP = addr.String()
-			break
+			return addr.String()
 		}
 	}
+	return ""
+}
 
-	expectedPublicIPv6 := linode.IPv6
-	if uuid == linode.HostUUID && node.Spec.ProviderID != "" && configuredPrivateIP == expectedPrivateIP && configuredPublicIPv6 == expectedPublicIPv6 {
-		s.SetLastMetadataUpdate(node.Name)
-		return nil
-	}
-
+// updateNodeMetadata persists the linode's UUID, provider ID, private IP, and
+// public IPv6 onto the node, retrying on update conflicts.
+func (s *nodeController) updateNodeMetadata(ctx context.Context, node *v1.Node, linode *linodego.Instance, privateIP, publicIPv6 string) (*v1.Node, error) {
 	var updatedNode *v1.Node
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Get a fresh copy of the node so the resource version is up-to-date
 		nodeResult, err := s.kubeclient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
 		if err != nil {
@@ -327,15 +322,45 @@ func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
 		}
 
 		// Try to update the expectedPrivateIP if its not set or doesn't match
-		if nodeResult.Annotations[annotations.AnnLinodeNodePrivateIP] != expectedPrivateIP && expectedPrivateIP != "" {
-			nodeResult.Annotations[annotations.AnnLinodeNodePrivateIP] = expectedPrivateIP
+		if nodeResult.Annotations[annotations.AnnLinodeNodePrivateIP] != privateIP && privateIP != "" {
+			nodeResult.Annotations[annotations.AnnLinodeNodePrivateIP] = privateIP
 		}
-		if nodeResult.Annotations[annotations.AnnLinodeNodePublicIPv6] != expectedPublicIPv6 && expectedPublicIPv6 != "" {
-			nodeResult.Annotations[annotations.AnnLinodeNodePublicIPv6] = expectedPublicIPv6
+		if nodeResult.Annotations[annotations.AnnLinodeNodePublicIPv6] != publicIPv6 && publicIPv6 != "" {
+			nodeResult.Annotations[annotations.AnnLinodeNodePublicIPv6] = publicIPv6
 		}
 		updatedNode, err = s.kubeclient.CoreV1().Nodes().Update(ctx, nodeResult, metav1.UpdateOptions{})
 		return err
-	}); err != nil {
+	})
+	return updatedNode, err
+}
+
+func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
+	klog.V(3).InfoS("NodeController handling node metadata",
+		"node", klog.KObj(node))
+
+	if !s.metadataNeedsRefresh(node) {
+		return nil
+	}
+
+	linode, err := s.instances.LookupLinode(ctx, node)
+	if err != nil {
+		klog.V(1).ErrorS(err, "Instance lookup error")
+		return err
+	}
+
+	uuid := node.Labels[annotations.AnnLinodeHostUUID]
+	configuredPrivateIP := node.Annotations[annotations.AnnLinodeNodePrivateIP]
+	configuredPublicIPv6 := node.Annotations[annotations.AnnLinodeNodePublicIPv6]
+
+	privateIP := expectedPrivateIP(linode)
+	publicIPv6 := linode.IPv6
+	if uuid == linode.HostUUID && node.Spec.ProviderID != "" && configuredPrivateIP == privateIP && configuredPublicIPv6 == publicIPv6 {
+		s.SetLastMetadataUpdate(node.Name)
+		return nil
+	}
+
+	updatedNode, err := s.updateNodeMetadata(ctx, node, linode, privateIP, publicIPv6)
+	if err != nil {
 		klog.V(1).ErrorS(err, "Node update error")
 		return err
 	}

--- a/cloud/linode/services/firewalls.go
+++ b/cloud/linode/services/firewalls.go
@@ -85,22 +85,43 @@ func (l *LinodeClient) DeleteNodeBalancerFirewall(
 	return nil
 }
 
+// collectRuleIPs flattens the IPv4 and IPv6 addresses across all inbound
+// firewall rules.
+func collectRuleIPs(rules []linodego.FirewallRuleInbound) (ipv4s, ipv6s []string) {
+	for _, rule := range rules {
+		if rule.Addresses.IPv4 != nil {
+			ipv4s = append(ipv4s, rule.Addresses.IPv4...)
+		}
+		if rule.Addresses.IPv6 != nil {
+			ipv6s = append(ipv6s, rule.Addresses.IPv6...)
+		}
+	}
+	return ipv4s, ipv6s
+}
+
+// ipListChanged reports whether ips differs from the ruleIPs collected from
+// firewall rules.
+func ipListChanged(ips []string, ruleIPs []string) bool {
+	if ips == nil {
+		return false
+	}
+	if len(ips) != len(ruleIPs) {
+		return true
+	}
+	for _, ip := range ips {
+		if !slices.Contains(ruleIPs, ip) {
+			return true
+		}
+	}
+	return false
+}
+
 func ipsChanged(ips *linodego.NetworkAddresses, rules []linodego.FirewallRuleInbound) bool {
 	if ips == nil {
 		return false
 	}
 
-	var ruleIPv4s []string
-	var ruleIPv6s []string
-
-	for _, rule := range rules {
-		if rule.Addresses.IPv4 != nil {
-			ruleIPv4s = append(ruleIPv4s, rule.Addresses.IPv4...)
-		}
-		if rule.Addresses.IPv6 != nil {
-			ruleIPv6s = append(ruleIPv6s, rule.Addresses.IPv6...)
-		}
-	}
+	ruleIPv4s, ruleIPv6s := collectRuleIPs(rules)
 
 	if len(ruleIPv4s) > 0 && ips.IPv4 == nil {
 		return true
@@ -110,26 +131,12 @@ func ipsChanged(ips *linodego.NetworkAddresses, rules []linodego.FirewallRuleInb
 		return true
 	}
 
-	if ips.IPv4 != nil {
-		if len(ips.IPv4) != len(ruleIPv4s) {
-			return true
-		}
-		for _, ipv4 := range ips.IPv4 {
-			if !slices.Contains(ruleIPv4s, ipv4) {
-				return true
-			}
-		}
+	if ipListChanged(ips.IPv4, ruleIPv4s) {
+		return true
 	}
 
-	if ips.IPv6 != nil {
-		if len(ips.IPv6) != len(ruleIPv6s) {
-			return true
-		}
-		for _, ipv6 := range ips.IPv6 {
-			if !slices.Contains(ruleIPv6s, ipv6) {
-				return true
-			}
-		}
+	if ipListChanged(ips.IPv6, ruleIPv6s) {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
Adds the cyclop linter and addresses 4 issues found, splitting the problematic functions to use smaller helpers.
```
cloud/linode/cloud.go:179:1: calculated cyclomatic complexity for function newCloud is 24, max is 15 (cyclop)
func newCloud() (cloudprovider.Interface, error) {
^
cloud/linode/loadbalancers.go:958:1: calculated cyclomatic complexity for function buildNodeBalancerConfig is 21, max is 15 (cyclop)
func (l *loadbalancers) buildNodeBalancerConfig(ctx context.Context, service *v1.Service, port v1.ServicePort) (linodego.NodeBalancerConfig, error) {
^
cloud/linode/node_controller.go:269:1: calculated cyclomatic complexity for function handleNode is 21, max is 15 (cyclop)
func (s *nodeController) handleNode(ctx context.Context, node *v1.Node) error {
^
cloud/linode/services/firewalls.go:88:1: calculated cyclomatic complexity for function ipsChanged is 17, max is 15 (cyclop)
func ipsChanged(ips *linodego.NetworkAddresses, rules []linodego.FirewallRuleInbound) bool {
^
4 issues:
* cyclop: 4
```