### PR TITLE
[CI] gosec is already run by golangci-lint

### DIFF
--- a/.github/workflows/go-analyze.yml
+++ b/.github/workflows/go-analyze.yml
@@ -90,6 +90,3 @@ jobs:
 
       - name: Vulncheck
         run: mise run vulncheck
-
-      - name: Gosec
-        run: mise run gosec

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,6 @@ lint:
 lint-fix:
 	golangci-lint run -c .golangci.yml --fix
 
-.PHONY: gosec
-gosec: ## Run gosec against code.
-	gosec -exclude-dir=bin -confidence medium -terse -exclude-generated ./...
-
 .PHONY: vulncheck
 vulncheck: ## Run vulnerability check against code.
 	./hack/vulncheck.sh

--- a/mise.toml
+++ b/mise.toml
@@ -18,7 +18,6 @@ ko = "0.19.1"
 "go:github.com/kyverno/chainsaw" = "0.2.15"
 "go:golang.org/x/vuln/cmd/govulncheck" = "1.1.4"
 "go:github.com/golang/mock/mockgen" = "1.6.0"
-"aqua:securego/gosec" = "2.28.0"
 yq = "4.52.2"
 jq = "1.8.1"
 envsubst = "1.4.3"
@@ -46,10 +45,6 @@ run = "make ko-publish"
 [tasks.fmt]
 description = "Run go fmt"
 run = "make fmt"
-
-[tasks.gosec]
-description = "Run gosec in the project containerized workflow"
-run = "make gosec"
 
 [tasks.helm-lint]
 description = "Lint the Helm chart"


### PR DESCRIPTION
Removes redundant gosec check since golangci-lint already handles it and it's enabled in the .golangci.yml: https://golangci-lint.run/docs/linters/configuration/#gosec

Vulncheck and Nilaway still aren't included linters though so those stay.
