### PR TITLE
[improvement] enable nestif linter and address issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,7 @@ linters:
     - misspell
     - mnd
     - musttag
+    - nestif
     - nilerr
     - nilnesserr
     - nilnil

--- a/cloud/linode/loadbalancers.go
+++ b/cloud/linode/loadbalancers.go
@@ -264,30 +264,20 @@ func (l *loadbalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 	var nb *linodego.NodeBalancer
 
 	nb, err = l.getNodeBalancerForService(ctx, service)
-	if err == nil {
+	var targetError lbNotFoundError
+	switch {
+	case err == nil:
 		if err = l.updateNodeBalancer(ctx, clusterName, service, nodes, nb); err != nil {
 			sentry.CaptureError(ctx, err)
 			return nil, err
 		}
-	} else {
-		var targetError lbNotFoundError
-		if errors.As(err, &targetError) {
-			if service.GetAnnotations()[annotations.AnnLinodeNodeBalancerID] != "" {
-				// a load balancer annotation has been created so a NodeBalancer is coming, error out and retry later
-				klog.Infof("NodeBalancer created but not available yet, waiting...")
-				sentry.CaptureError(ctx, err)
-				return nil, err
-			}
-
-			if nb, err = l.buildLoadBalancerRequest(ctx, clusterName, service, nodes); err != nil {
-				sentry.CaptureError(ctx, err)
-				return nil, err
-			}
-			klog.Infof("created new NodeBalancer (%d) for service (%s)", nb.ID, serviceNn)
-		} else {
-			sentry.CaptureError(ctx, err)
+	case errors.As(err, &targetError):
+		if nb, err = l.createNodeBalancerForMissingService(ctx, clusterName, service, nodes, err); err != nil {
 			return nil, err
 		}
+	default:
+		sentry.CaptureError(ctx, err)
+		return nil, err
 	}
 
 	klog.Infof("NodeBalancer (%d) has been ensured for service (%s)", nb.ID, serviceNn)
@@ -301,6 +291,26 @@ func (l *loadbalancers) EnsureLoadBalancer(ctx context.Context, clusterName stri
 	}
 
 	return lbStatus, nil
+}
+
+// createNodeBalancerForMissingService handles the case where getNodeBalancerForService returned
+// an lbNotFoundError: either a NodeBalancer is still being created (annotation already set) or a
+// brand new NodeBalancer needs to be built for the service.
+func (l *loadbalancers) createNodeBalancerForMissingService(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node, notFoundErr error) (*linodego.NodeBalancer, error) {
+	if service.GetAnnotations()[annotations.AnnLinodeNodeBalancerID] != "" {
+		// a load balancer annotation has been created so a NodeBalancer is coming, error out and retry later
+		klog.Infof("NodeBalancer created but not available yet, waiting...")
+		sentry.CaptureError(ctx, notFoundErr)
+		return nil, notFoundErr
+	}
+
+	nb, err := l.buildLoadBalancerRequest(ctx, clusterName, service, nodes)
+	if err != nil {
+		sentry.CaptureError(ctx, err)
+		return nil, err
+	}
+	klog.Infof("created new NodeBalancer (%d) for service (%s)", nb.ID, getServiceNn(service))
+	return nb, nil
 }
 
 func (l *loadbalancers) createIPChangeWarningEvent(ctx context.Context, service *v1.Service, nb *linodego.NodeBalancer, newIP string) {
@@ -931,32 +941,38 @@ func (l *loadbalancers) createNodeBalancer(ctx context.Context, clusterName stri
 		createOpts.IPv4 = &ipv4
 	}
 
-	fwid, ok := service.GetAnnotations()[annotations.AnnLinodeCloudFirewallID]
-	if ok {
+	if fwid, ok := service.GetAnnotations()[annotations.AnnLinodeCloudFirewallID]; ok {
 		firewallID, err := strconv.Atoi(fwid)
 		if err != nil {
 			return nil, err
 		}
 		createOpts.FirewallID = firewallID
-	} else {
+	} else if _, ok := service.GetAnnotations()[annotations.AnnLinodeCloudFirewallACL]; ok {
 		// There's no firewallID already set, see if we need to create a new fw, look for the acl annotation.
-		_, ok := service.GetAnnotations()[annotations.AnnLinodeCloudFirewallACL]
-		if ok {
-			fwcreateOpts, err := services.CreateFirewallOptsForSvc(label, tags, service)
-			if err != nil {
-				return nil, err
-			}
-
-			fw, err := l.client.CreateFirewall(ctx, *fwcreateOpts)
-			if err != nil {
-				return nil, err
-			}
-			createOpts.FirewallID = fw.ID
+		firewallID, err := l.createFirewallForNodeBalancer(ctx, label, tags, service)
+		if err != nil {
+			return nil, err
 		}
-		// no need to deal with firewalls, continue creating nb's
+		createOpts.FirewallID = firewallID
 	}
+	// no need to deal with firewalls, continue creating nb's
 
 	return l.client.CreateNodeBalancer(ctx, createOpts)
+}
+
+// createFirewallForNodeBalancer creates a new Cloud Firewall from the service's ACL annotation
+// and returns its ID, for use as the NodeBalancer's FirewallID.
+func (l *loadbalancers) createFirewallForNodeBalancer(ctx context.Context, label string, tags []string, service *v1.Service) (int, error) {
+	fwcreateOpts, err := services.CreateFirewallOptsForSvc(label, tags, service)
+	if err != nil {
+		return 0, err
+	}
+
+	fw, err := l.client.CreateFirewall(ctx, *fwcreateOpts)
+	if err != nil {
+		return 0, err
+	}
+	return fw.ID, nil
 }
 
 // applyHealthCheckBody sets the config's health check path/body based on the
@@ -1456,23 +1472,28 @@ func getTLSCertInfo(ctx context.Context, kubeClient kubernetes.Interface, namesp
 }
 
 func getConnectionThrottle(service *v1.Service) int {
-	connThrottle := 0 // disable throttle if nothing is specified
-
-	if connThrottleString := service.GetAnnotations()[annotations.AnnLinodeThrottle]; connThrottleString != "" {
-		parsed, err := strconv.Atoi(connThrottleString)
-		if err == nil {
-			if parsed < 0 {
-				parsed = 0
-			}
-
-			if parsed > maxConnThrottleStringLen {
-				parsed = maxConnThrottleStringLen
-			}
-			connThrottle = parsed
-		}
+	connThrottleString := service.GetAnnotations()[annotations.AnnLinodeThrottle]
+	if connThrottleString == "" {
+		return 0 // disable throttle if nothing is specified
 	}
 
-	return connThrottle
+	parsed, err := strconv.Atoi(connThrottleString)
+	if err != nil {
+		return 0
+	}
+
+	return clampConnThrottle(parsed)
+}
+
+func clampConnThrottle(parsed int) int {
+	switch {
+	case parsed < 0:
+		return 0
+	case parsed > maxConnThrottleStringLen:
+		return maxConnThrottleStringLen
+	default:
+		return parsed
+	}
 }
 
 func makeLoadBalancerStatus(service *v1.Service, nb *linodego.NodeBalancer) *v1.LoadBalancerStatus {

--- a/cloud/linode/services/firewalls.go
+++ b/cloud/linode/services/firewalls.go
@@ -142,29 +142,39 @@ func ipsChanged(ips *linodego.NetworkAddresses, rules []linodego.FirewallRuleInb
 	return false
 }
 
+func parsePortRange(part string) ([]int32, error) {
+	rangeParts := strings.Split(part, "-")
+	if len(rangeParts) != portRangeParts {
+		return nil, fmt.Errorf("invalid range format: %s", part)
+	}
+
+	start, err1 := strconv.ParseInt(rangeParts[0], 10, 32)
+	end, err2 := strconv.ParseInt(rangeParts[1], 10, 32)
+	if err1 != nil || err2 != nil {
+		return nil, fmt.Errorf("invalid number in range: %s", part)
+	}
+	if start > end {
+		return nil, fmt.Errorf("start greater than end in range: %s", part)
+	}
+
+	result := make([]int32, 0, end-start+1)
+	for i := start; i <= end; i++ {
+		result = append(result, int32(i)) // #nosec G115: Integer overflow conversion is safe for port numbers
+	}
+	return result, nil
+}
+
 func parsePorts(ports string) ([]int32, error) {
 	var result []int32
 	portParts := strings.Split(ports, ",")
 	for _, part := range portParts {
 		part = strings.TrimSpace(part)
 		if strings.Contains(part, "-") {
-			rangeParts := strings.Split(part, "-")
-			if len(rangeParts) != portRangeParts {
-				return nil, fmt.Errorf("invalid range format: %s", part)
+			rangePorts, err := parsePortRange(part)
+			if err != nil {
+				return nil, err
 			}
-
-			start, err1 := strconv.ParseInt(rangeParts[0], 10, 32)
-			end, err2 := strconv.ParseInt(rangeParts[1], 10, 32)
-			if err1 != nil || err2 != nil {
-				return nil, fmt.Errorf("invalid number in range: %s", part)
-			}
-			if start > end {
-				return nil, fmt.Errorf("start greater than end in range: %s", part)
-			}
-
-			for i := start; i <= end; i++ {
-				result = append(result, int32(i)) // #nosec G115: Integer overflow conversion is safe for port numbers
-			}
+			result = append(result, rangePorts...)
 		} else {
 			port, err := strconv.ParseInt(part, 10, 32)
 			if err != nil {
@@ -485,31 +495,39 @@ func (l *LinodeClient) updateServiceFirewall(ctx context.Context, service *v1.Se
 	}
 	// if existing firewall and new firewall differs, attach the new firewall and remove the old.
 	if existingFirewallID != newFirewallID {
-		// attach new firewall.
-		_, err = l.Client.CreateFirewallDevice(ctx, newFirewallID, linodego.FirewallDeviceCreateOptions{
-			ID:   nb.ID,
-			Type: "nodebalancer",
-		})
-		if err != nil {
+		if err := l.attachAndReplaceNBFirewall(ctx, nb.ID, existingFirewallID, newFirewallID); err != nil {
 			return err
-		}
-		// remove the existing firewall if it exists
-		if existingFirewallID != 0 {
-			deviceID, deviceExists, err := l.getNodeBalancerDeviceID(ctx, existingFirewallID, nb.ID)
-			if err != nil {
-				return err
-			}
-
-			if !deviceExists {
-				return fmt.Errorf("error in fetching attached nodeBalancer device")
-			}
-
-			if deleteErr := l.Client.DeleteFirewallDevice(ctx, existingFirewallID, deviceID); deleteErr != nil {
-				return deleteErr
-			}
 		}
 	}
 	return nil
+}
+
+// attachAndReplaceNBFirewall attaches newFirewallID to the NodeBalancer and, if an existing
+// firewall was previously attached, detaches and removes it.
+func (l *LinodeClient) attachAndReplaceNBFirewall(ctx context.Context, nbID, existingFirewallID, newFirewallID int) error {
+	// attach new firewall.
+	if _, err := l.Client.CreateFirewallDevice(ctx, newFirewallID, linodego.FirewallDeviceCreateOptions{
+		ID:   nbID,
+		Type: "nodebalancer",
+	}); err != nil {
+		return err
+	}
+
+	// remove the existing firewall if it exists
+	if existingFirewallID == 0 {
+		return nil
+	}
+
+	deviceID, deviceExists, err := l.getNodeBalancerDeviceID(ctx, existingFirewallID, nbID)
+	if err != nil {
+		return err
+	}
+
+	if !deviceExists {
+		return fmt.Errorf("error in fetching attached nodeBalancer device")
+	}
+
+	return l.Client.DeleteFirewallDevice(ctx, existingFirewallID, deviceID)
 }
 
 func (l *LinodeClient) updateNodeBalancerFirewallWithACL(

--- a/cloud/nodeipam/ipam/cloud_allocator_test.go
+++ b/cloud/nodeipam/ipam/cloud_allocator_test.go
@@ -1024,6 +1024,31 @@ type releaseTestCase struct {
 	instance                         *linodego.Instance
 }
 
+// checkFirstRoundAllocation verifies the outcome of the first AllocateOrOccupyCIDR call for tc,
+// asserting either a successful allocation with node update, or an expected failure with no update.
+func checkFirstRoundAllocation(t *testing.T, tc releaseTestCase, err error) {
+	t.Helper()
+
+	if len(tc.expectedAllocatedCIDRFirstRound) == 0 {
+		if err == nil {
+			t.Fatalf("%v: unexpected success in AllocateOrOccupyCIDR: %v", tc.description, err)
+		}
+		// We don't expect any updates here
+		time.Sleep(time.Second)
+		if len(tc.fakeNodeHandler.GetUpdatedNodesCopy()) != 0 {
+			t.Fatalf("%v: unexpected update of nodes: %v", tc.description, tc.fakeNodeHandler.GetUpdatedNodesCopy())
+		}
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("%v: unexpected error in AllocateOrOccupyCIDR: %v", tc.description, err)
+	}
+	if err = test.WaitForUpdatedNodeWithTimeout(tc.fakeNodeHandler, 1, wait.ForeverTestTimeout); err != nil {
+		t.Fatalf("%v: timeout while waiting for Node update: %v", tc.description, err)
+	}
+}
+
 func TestReleaseCIDRSuccess(t *testing.T) {
 	// Non-parallel test (overrides global var)
 	oldNodePollInterval := nodePollInterval
@@ -1279,23 +1304,7 @@ func TestReleaseCIDRSuccess(t *testing.T) {
 		}
 
 		err := allocator.AllocateOrOccupyCIDR(tCtx, tc.fakeNodeHandler.Existing[0])
-		if len(tc.expectedAllocatedCIDRFirstRound) != 0 {
-			if err != nil {
-				t.Fatalf("%v: unexpected error in AllocateOrOccupyCIDR: %v", tc.description, err)
-			}
-			if err = test.WaitForUpdatedNodeWithTimeout(tc.fakeNodeHandler, 1, wait.ForeverTestTimeout); err != nil {
-				t.Fatalf("%v: timeout while waiting for Node update: %v", tc.description, err)
-			}
-		} else {
-			if err == nil {
-				t.Fatalf("%v: unexpected success in AllocateOrOccupyCIDR: %v", tc.description, err)
-			}
-			// We don't expect any updates here
-			time.Sleep(time.Second)
-			if len(tc.fakeNodeHandler.GetUpdatedNodesCopy()) != 0 {
-				t.Fatalf("%v: unexpected update of nodes: %v", tc.description, tc.fakeNodeHandler.GetUpdatedNodesCopy())
-			}
-		}
+		checkFirstRoundAllocation(t, tc, err)
 		for _, cidrToRelease := range tc.cidrsToRelease {
 			nodeToRelease := v1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Adds the nestif linter and addresses 6 issues found, splitting the problematic functions to use smaller helpers:
```
cloud/linode/loadbalancers.go:267:1: `if err == nil` has complex nested blocks (complexity: 8) (nestif)
	if err == nil {
^
cloud/linode/loadbalancers.go:935:1: `if ok` has complex nested blocks (complexity: 7) (nestif)
	if ok {
^
cloud/linode/loadbalancers.go:1461:1: `if connThrottleString != ""` has complex nested blocks (complexity: 5) (nestif)
	if connThrottleString := service.GetAnnotations()[annotations.AnnLinodeThrottle]; connThrottleString != "" {
^
cloud/linode/services/firewalls.go:150:1: `if strings.Contains(part, "-")` has complex nested blocks (complexity: 5) (nestif)
		if strings.Contains(part, "-") {
^
cloud/linode/services/firewalls.go:487:1: `if existingFirewallID != newFirewallID` has complex nested blocks (complexity: 8) (nestif)
	if existingFirewallID != newFirewallID {
^
cloud/nodeipam/ipam/cloud_allocator_test.go:1282:1: `if len(tc.expectedAllocatedCIDRFirstRound) != 0` has complex nested blocks (complexity: 5) (nestif)
		if len(tc.expectedAllocatedCIDRFirstRound) != 0 {
^
6 issues:
* nestif: 6
```
