### PR TITLE
[fix]: Chunked cloud firewall rules of only 1 addr type result in empty rule and failed updates

### DIFF
--- a/cloud/linode/services/firewalls.go
+++ b/cloud/linode/services/firewalls.go
@@ -265,8 +265,11 @@ func chunkIPs(ips []string) [][]string {
 	ipCount := len(ips)
 
 	// If the number of IPs is less than or equal to maxIPsPerFirewall,
-	// return a single chunk containing all IPs.
+	// return a single chunk containing all IPs, or nil if chunking an empty slice.
 	if ipCount <= maxIPsPerFirewall {
+		if ipCount == 0 {
+			return nil
+		}
 		return [][]string{ips}
 	}
 

--- a/cloud/linode/services/firewalls_test.go
+++ b/cloud/linode/services/firewalls_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -76,6 +77,25 @@ func TestRuleChanged(t *testing.T) {
 				t.Errorf("ruleChanged() = %v, want %v", got, tc.wantChange)
 			}
 		})
+	}
+}
+
+func TestProcessACLNoEmptyRuleForMissingFamily(t *testing.T) {
+	ipv4s := make([]string, 256)
+	for i := range ipv4s {
+		ipv4s[i] = fmt.Sprintf("10.0.%d.1/32", i)
+	}
+
+	fwcreateOpts := &linodego.FirewallCreateOptions{}
+	err := processACL(fwcreateOpts, accept, "test", "svc", "80", linodego.NetworkAddresses{IPv4: ipv4s})
+	if err != nil {
+		t.Fatalf("processACL() error = %v", err)
+	}
+
+	for _, rule := range fwcreateOpts.Rules.Inbound {
+		if len(rule.Addresses.IPv4) == 0 && len(rule.Addresses.IPv6) == 0 {
+			t.Errorf("processACL() created an inbound rule with no addresses: %+v", rule)
+		}
 	}
 }
 

--- a/cloud/linode/services/firewalls_test.go
+++ b/cloud/linode/services/firewalls_test.go
@@ -80,22 +80,73 @@ func TestRuleChanged(t *testing.T) {
 	}
 }
 
+// generateCIDRs builds count distinct CIDRs using the given per-index formatter,
+// e.g. an IPv4 /32 or an IPv6 /128 formatter.
+func generateCIDRs(count int, format func(i int) string) []string {
+	ips := make([]string, count)
+	for i := range ips {
+		ips[i] = format(i)
+	}
+	return ips
+}
+
+// TestProcessACLNoEmptyRuleForMissingFamily is a regression test for a bug where
+// processACL created an empty inbound rule for the IP family with no addresses
+// when the other family exceeded maxIPsPerFirewall (255), because chunkIPs
+// returns a single chunk for an empty slice. It exercises both single-family
+// cases (IPv4-only and the symmetric IPv6-only case) with 256 addresses, which
+// must be split into exactly two chunks: 255 and 1.
 func TestProcessACLNoEmptyRuleForMissingFamily(t *testing.T) {
-	ipv4s := make([]string, 256)
-	for i := range ipv4s {
-		ipv4s[i] = fmt.Sprintf("10.0.%d.1/32", i)
+	const addrCount = 256
+	wantChunkSizes := []int{255, 1}
+
+	tests := []struct {
+		name string
+		ips  linodego.NetworkAddresses
+	}{
+		{
+			name: "IPv4Only",
+			ips: linodego.NetworkAddresses{
+				IPv4: generateCIDRs(addrCount, func(i int) string { return fmt.Sprintf("10.0.%d.1/32", i) }),
+			},
+		},
+		{
+			name: "IPv6Only",
+			ips: linodego.NetworkAddresses{
+				IPv6: generateCIDRs(addrCount, func(i int) string { return fmt.Sprintf("2001:db8::%x/128", i) }),
+			},
+		},
 	}
 
-	fwcreateOpts := &linodego.FirewallCreateOptions{}
-	err := processACL(fwcreateOpts, accept, "test", "svc", "80", linodego.NetworkAddresses{IPv4: ipv4s})
-	if err != nil {
-		t.Fatalf("processACL() error = %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fwcreateOpts := &linodego.FirewallCreateOptions{}
+			err := processACL(fwcreateOpts, accept, "test", "svc", "80", tt.ips)
+			if err != nil {
+				t.Fatalf("processACL() error = %v", err)
+			}
 
-	for _, rule := range fwcreateOpts.Rules.Inbound {
-		if len(rule.Addresses.IPv4) == 0 && len(rule.Addresses.IPv6) == 0 {
-			t.Errorf("processACL() created an inbound rule with no addresses: %+v", rule)
-		}
+			if len(fwcreateOpts.Rules.Inbound) != len(wantChunkSizes) {
+				t.Fatalf("processACL() created %d inbound rules, want %d", len(fwcreateOpts.Rules.Inbound), len(wantChunkSizes))
+			}
+
+			for i, rule := range fwcreateOpts.Rules.Inbound {
+				if len(rule.Addresses.IPv4) == 0 && len(rule.Addresses.IPv6) == 0 {
+					t.Errorf("processACL() created an inbound rule with no addresses: %+v", rule)
+				}
+
+				if gotSize := len(rule.Addresses.IPv4) + len(rule.Addresses.IPv6); gotSize != wantChunkSizes[i] {
+					t.Errorf("rule %d has %d addresses, want %d", i, gotSize, wantChunkSizes[i])
+				}
+
+				if len(tt.ips.IPv4) > 0 && len(rule.Addresses.IPv6) != 0 {
+					t.Errorf("rule %d unexpectedly has IPv6 addresses for an IPv4-only ACL: %+v", i, rule)
+				}
+				if len(tt.ips.IPv6) > 0 && len(rule.Addresses.IPv4) != 0 {
+					t.Errorf("rule %d unexpectedly has IPv4 addresses for an IPv6-only ACL: %+v", i, rule)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](.github/CONTRIBUTING.md). -->
<!-- Ensure your PR title complies with the following guidelines
    1. All PRs titles should start with one of the following prefixes
         - `[fix]` for PRs related to bug fixes and patches
         - `[feat]` for PRs related to new features
         - `[improvement]` for PRs related to improvements of existing features
         - `[test]` for PRs related to tests
         - `[CI]` for PRs related to repo CI improvements
         - `[docs]` for PRs related to documentation updates
         - `[deps]` for PRs related to dependency updates
   2. if a PR introduces a breaking change it should include `[breaking]` in the title
   3. if a PR introduces a deprecation it should include `[deprecation]` in the title
-->
### General:

* [x] Have you removed all sensitive information, including but not limited to access keys and passwords?
* [x] Have you checked to ensure there aren't other open or closed [Pull Requests](../../pulls) for the same bug/feature/question?

### Pull Request Guidelines:

1. [x] Does your submission pass tests?
1. [x] Have you added tests? 
1. [x] Are you addressing a single feature in this PR? 
1. [x] Are your commits atomic, addressing one change per commit?
1. [x] Are you following the conventions of the language? 
1. [x] Have you saved your large formatting changes for a different PR, so we can focus on your work?
1. [x] Have you explained your rationale for why this feature is needed? 
1. [ ] Have you linked your PR to an [open issue](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)

### Description

tl;dr — if you have a large firewall that exceeds the 255 address limit and kicks in the chunking logic, if that large firewall rule contains only 1 address type (i.e. all IPv4 or all IPv6) then the CCM still tries to add an empty rule for the address type.

This does the dumb, simple thing of just checking the length of the rules for each addr type before chunking them.

Example with a big rule of only IPv4 addrs:

```console
 I0831 16:54:33.298782   37901 firewalls.go:305] Firewall label 'ACCEPT-platform-components-gateway-istio' is too long. Stripping to
 'ACCEPT-platform-components-gatew'
 inbound rules: 3
 rule 0: IPv4=255 IPv6=0
 rule 1: IPv4=9 IPv6=0
 rule 2: IPv4=0 IPv6=0
```